### PR TITLE
DateTime instead of DateTimeOffset; resolves #4

### DIFF
--- a/src/OpenTracing.BasicTracer/LogData.cs
+++ b/src/OpenTracing.BasicTracer/LogData.cs
@@ -4,14 +4,14 @@ namespace OpenTracing.BasicTracer
 {
     public struct LogData
     {
-        public LogData(DateTimeOffset timestamp, string eventName, object payload)
+        public LogData(DateTime timestamp, string eventName, object payload)
         {
             Timestamp = timestamp;
             EventName = eventName;
             Payload = payload;
         }
 
-        public DateTimeOffset Timestamp { get; private set; }
+        public DateTime Timestamp { get; private set; }
         public string EventName { get; private set; }
         public object Payload { get; private set; }
     }

--- a/src/OpenTracing.BasicTracer/Span.cs
+++ b/src/OpenTracing.BasicTracer/Span.cs
@@ -12,8 +12,8 @@ namespace OpenTracing.BasicTracer
         public ISpanContext Context => _context;
 
         public string OperationName { get; private set; }
-        public DateTimeOffset StartTimestamp { get; }
-        public DateTimeOffset? FinishTimestamp { get; private set; }
+        public DateTime StartTimestamp { get; }
+        public DateTime? FinishTimestamp { get; private set; }
 
         public IDictionary<string, object> Tags { get; } = new Dictionary<string, object>();
         public IList<LogData> Logs { get; } = new List<LogData>();
@@ -22,7 +22,7 @@ namespace OpenTracing.BasicTracer
             ISpanRecorder spanRecorder,
             SpanContext context,
             string operationName,
-            DateTimeOffset startTimestamp,
+            DateTime startTimestamp,
             IDictionary<string, object> tags)
         {
             if (spanRecorder == null)
@@ -79,10 +79,10 @@ namespace OpenTracing.BasicTracer
 
         public virtual ISpan LogEvent(string eventName, object payload = null)
         {
-            return LogEvent(DateTimeOffset.UtcNow, eventName, payload);
+            return LogEvent(DateTime.UtcNow, eventName, payload);
         }
 
-        public virtual ISpan LogEvent(DateTimeOffset timestamp, string eventName, object payload = null)
+        public virtual ISpan LogEvent(DateTime timestamp, string eventName, object payload = null)
         {
             if (string.IsNullOrWhiteSpace(eventName))
             {
@@ -104,12 +104,12 @@ namespace OpenTracing.BasicTracer
             return _context.GetBaggageItem(key);
         }
 
-        public virtual void Finish(DateTimeOffset? finishTimestamp = null)
+        public virtual void Finish(DateTime? finishTimestamp = null)
         {
             if (FinishTimestamp.HasValue)
                 return;
 
-            FinishTimestamp = finishTimestamp ?? DateTimeOffset.UtcNow;
+            FinishTimestamp = finishTimestamp ?? DateTime.UtcNow;
             OnFinished();
         }
 

--- a/src/OpenTracing.BasicTracer/SpanBuilder.cs
+++ b/src/OpenTracing.BasicTracer/SpanBuilder.cs
@@ -17,7 +17,7 @@ namespace OpenTracing.BasicTracer
         // not initialized to save allocations in case there are no tags.
         private IDictionary<string, object> _tags;
         
-        private DateTimeOffset? _startTimestamp;
+        private DateTime? _startTimestamp;
 
         public SpanBuilder(Tracer tracer, string operationName)
         {
@@ -80,7 +80,7 @@ namespace OpenTracing.BasicTracer
             return this;
         }
 
-        public ISpanBuilder WithStartTimestamp(DateTimeOffset startTimestamp)
+        public ISpanBuilder WithStartTimestamp(DateTime startTimestamp)
         {
             _startTimestamp = startTimestamp;
             return this;

--- a/src/OpenTracing.BasicTracer/SpanData.cs
+++ b/src/OpenTracing.BasicTracer/SpanData.cs
@@ -7,7 +7,7 @@ namespace OpenTracing.BasicTracer
     {
         public SpanContext Context { get; internal set; }
         public string OperationName { get; internal set; }
-        public DateTimeOffset StartTimestamp { get; internal set; }
+        public DateTime StartTimestamp { get; internal set; }
         public TimeSpan Duration { get; internal set; }
         public IDictionary<string, object> Tags { get; internal set; }
         public IList<LogData> LogData { get; internal set; }

--- a/src/OpenTracing.BasicTracer/Tracer.cs
+++ b/src/OpenTracing.BasicTracer/Tracer.cs
@@ -37,13 +37,13 @@ namespace OpenTracing.BasicTracer
 
         public ISpan StartSpan(
             string operationName,
-            DateTimeOffset? startTimestamp,
+            DateTime? startTimestamp,
             IList<SpanReference> references,
             IDictionary<string, object> tags)
         {
             var spanContext = _spanContextFactory.CreateSpanContext(references);
 
-            var span = new Span(_spanRecorder, spanContext, operationName, startTimestamp ?? DateTimeOffset.UtcNow, tags);
+            var span = new Span(_spanRecorder, spanContext, operationName, startTimestamp ?? DateTime.UtcNow, tags);
 
             return span;
         }

--- a/src/OpenTracing/ISpan.cs
+++ b/src/OpenTracing/ISpan.cs
@@ -8,8 +8,6 @@ namespace OpenTracing
     /// </summary>
     public interface ISpan : IDisposable
     {
-        // TODO DateTimeOffset vs ticks ?
-
         /// <summary>
         /// Returns the <see cref="ISpanContext"/> for this Span. Note that the return
         /// value of <see cref="Context"/> is still valid after a call to <see cref="Finish"/>, as is
@@ -45,11 +43,14 @@ namespace OpenTracing
         /// <summary>
         /// Records an event with optional payload data for this Span.
         /// </summary>
-        /// <param name="timestamp">The timestamp at which the event occured.</param>
+        /// <param name="timestamp">
+        ///   The timestamp of when the event occured.
+        ///   Use <see cref="DateTimeKind.Utc"/> whenever possible. The behavior of other kinds is not defined.
+        /// </param>
         /// <param name="eventName">Name of the event.</param>
         /// <param name="payload">An optional payload object.</param>
         /// <returns>The current <see cref="ISpan"/> instance for chaining.</returns>
-        ISpan LogEvent(DateTimeOffset timestamp, string eventName, object payload = null);
+        ISpan LogEvent(DateTime timestamp, string eventName, object payload = null);
 
         /// <summary>
         /// <para>Sets a baggage item in the Span (and its SpanContext) as a key/value pair.</para>
@@ -81,7 +82,10 @@ namespace OpenTracing
         /// otherwise leads to undefined behavior.
         /// </para>
         /// </summary>
-        /// <param name="finishTimestamp">The timestamp which should be used for the finish time of the Span.</param>
-        void Finish(DateTimeOffset? finishTimestamp = null);
+        /// <param name="finishTimestamp">
+        ///   The timestamp which should be used for the finish time of the Span.
+        ///   Use <see cref="DateTimeKind.Utc"/> whenever possible. The behavior of other kinds is not defined.
+        /// </param>
+        void Finish(DateTime? finishTimestamp = null);
     }
 }

--- a/src/OpenTracing/ISpanBuilder.cs
+++ b/src/OpenTracing/ISpanBuilder.cs
@@ -43,7 +43,11 @@ namespace OpenTracing
         /// <summary>
         /// Specify a timestamp of when the Span was started.
         /// </summary>
-        ISpanBuilder WithStartTimestamp(DateTimeOffset startTimestamp);
+        /// <param name="startTimestamp">
+        ///   The timestamp of when the Span was started.
+        ///   Use <see cref="DateTimeKind.Utc"/> whenever possible. The behavior of other kinds is not defined.
+        /// </param>
+        ISpanBuilder WithStartTimestamp(DateTime startTimestamp);
 
         /// <summary>
         /// Returns the started Span.

--- a/src/OpenTracing/NullTracer/NullSpan.cs
+++ b/src/OpenTracing/NullTracer/NullSpan.cs
@@ -27,7 +27,7 @@ namespace OpenTracing.NullTracer
             return this;
         }
 
-        public ISpan LogEvent(DateTimeOffset timestamp, string eventName, object payload = null)
+        public ISpan LogEvent(DateTime timestamp, string eventName, object payload = null)
         {
             return this;
         }
@@ -42,7 +42,7 @@ namespace OpenTracing.NullTracer
             return null;
         }
 
-        public void Finish(DateTimeOffset? finishTimestamp = null)
+        public void Finish(DateTime? finishTimestamp = null)
         {
         }
 

--- a/src/OpenTracing/NullTracer/NullSpanBuilder.cs
+++ b/src/OpenTracing/NullTracer/NullSpanBuilder.cs
@@ -35,7 +35,7 @@ namespace OpenTracing.NullTracer
             return this;
         }
 
-        public ISpanBuilder WithStartTimestamp(DateTimeOffset startTimestamp)
+        public ISpanBuilder WithStartTimestamp(DateTime startTimestamp)
         {
             return this;
         }


### PR DESCRIPTION
As discussed in #4 we are using DateTime instead of DateTimeOffset for the following reasons:

* It doesn't automatically convert values with DateTimeKind.Local
* We can let trace implementations decide whether they want to convert non-UTC values.
* It's the most-known type for users
* It's a little bit faster
* We can switch to DateTimeOffset later without breaking consumers because there's an implicit cast. (we would only break trace implementations)

I added a recommendation about using `DateTimeKind.Utc` in the comments of each usage.