### PR TITLE
Naming: SpanTags->Tags

### DIFF
--- a/src/OpenTracing/Extensions/SpanTagExtensions.cs
+++ b/src/OpenTracing/Extensions/SpanTagExtensions.cs
@@ -17,7 +17,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagSpanKind(this ISpan span, string spanKind)
         {
-            return SetTag(span, SpanTags.SpanKind, spanKind);
+            return SetTag(span, Tags.SpanKind, spanKind);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagComponent(this ISpan span, string component)
         {
-            return SetTag(span, SpanTags.Component, component);
+            return SetTag(span, Tags.Component, component);
         }
 
 
@@ -51,7 +51,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagHttpUrl(this ISpan span, string httpUrl)
         {
-            return SetTag(span, SpanTags.HttpUrl, httpUrl);
+            return SetTag(span, Tags.HttpUrl, httpUrl);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagHttpUrl(this ISpan span, Uri httpUrl)
         {
-            return SetTag(span, SpanTags.HttpUrl, httpUrl?.ToString());
+            return SetTag(span, Tags.HttpUrl, httpUrl?.ToString());
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagHttpMethod(this ISpan span, string httpMethod)
         {
-            return SetTag(span, SpanTags.HttpUrl, httpMethod);
+            return SetTag(span, Tags.HttpUrl, httpMethod);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagHttpMethod(this ISpan span, HttpMethod httpMethod)
         {
-            return SetTag(span, SpanTags.HttpUrl, httpMethod?.Method);
+            return SetTag(span, Tags.HttpUrl, httpMethod?.Method);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagHttpStatusCode(this ISpan span, int httpStatusCode)
         {
-            return SetTag(span, SpanTags.HttpStatusCode, httpStatusCode);
+            return SetTag(span, Tags.HttpStatusCode, httpStatusCode);
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagHttpStatusCode(this ISpan span, HttpStatusCode httpStatusCode)
         {
-            return SetTag(span, SpanTags.HttpStatusCode, httpStatusCode);
+            return SetTag(span, Tags.HttpStatusCode, httpStatusCode);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagPeerHostname(this ISpan span, string peerHostname)
         {
-            return SetTag(span, SpanTags.PeerHostname, peerHostname);
+            return SetTag(span, Tags.PeerHostname, peerHostname);
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagPeerIpV4(this ISpan span, string peerIpV4)
         {
-            return SetTag(span, SpanTags.PeerIpV4, peerIpV4);
+            return SetTag(span, Tags.PeerIpV4, peerIpV4);
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagPeerIpV6(this ISpan span, string peerIpV6)
         {
-            return SetTag(span, SpanTags.PeerIpV6, peerIpV6);
+            return SetTag(span, Tags.PeerIpV6, peerIpV6);
         }
 
 #if NETSTANDARD1_3
@@ -128,11 +128,11 @@ namespace OpenTracing
 
             if (peerIp.AddressFamily == AddressFamily.InterNetwork)
             {
-                return SetTag(span, SpanTags.PeerIpV4, peerIp.ToString());
+                return SetTag(span, Tags.PeerIpV4, peerIp.ToString());
             }
             else if (peerIp.AddressFamily == AddressFamily.InterNetworkV6)
             {
-                return SetTag(span, SpanTags.PeerIpV6, peerIp.ToString());
+                return SetTag(span, Tags.PeerIpV6, peerIp.ToString());
             }
             else
             {
@@ -146,7 +146,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagPeerPort(this ISpan span, int peerPort)
         {
-            return SetTag(span, SpanTags.PeerPort, peerPort);
+            return SetTag(span, Tags.PeerPort, peerPort);
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagPeerService(this ISpan span, string peerService)
         {
-            return SetTag(span, SpanTags.PeerService, peerService);
+            return SetTag(span, Tags.PeerService, peerService);
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagSamplingPriority(this ISpan span, int samplingPriority)
         {
-            return SetTag(span, SpanTags.SamplingPriority, samplingPriority);
+            return SetTag(span, Tags.SamplingPriority, samplingPriority);
         }
 
         /// <summary>
@@ -170,7 +170,7 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagError(this ISpan span, bool error = true)
         {
-            return SetTag(span, SpanTags.Error, error);
+            return SetTag(span, Tags.Error, error);
         }
 
 

--- a/src/OpenTracing/ISpan.cs
+++ b/src/OpenTracing/ISpan.cs
@@ -13,7 +13,7 @@ namespace OpenTracing
         /// value of <see cref="Context"/> is still valid after a call to <see cref="Finish"/>, as is
         /// a call to <see cref="Context"/> after a call to <see cref="Finish"/>.
         /// </summary>
-        ISpanContext Context { get; } // TODO property or method?
+        ISpanContext Context { get; }
 
         /// <summary>
         /// Sets or changes the operation name.

--- a/src/OpenTracing/Tags.cs
+++ b/src/OpenTracing/Tags.cs
@@ -1,9 +1,12 @@
 namespace OpenTracing
 {
     /// <summary>
-    /// Provides access to a list of common tag keys.
+    /// <para>The following span tags are recommended for instrumentors who are trying to capture more
+    /// semantic information about the spans. Tracers may expose additional features based on these
+    /// standardized data points. Tag names follow a general structure of namespacing.</para>
+    /// <para>See http://opentracing.io/data-semantics/ for details.</para>
     /// </summary>
-    public static class SpanTags
+    public static class Tags
     {
         /// <summary>
         ///  "component" is a low-cardinality identifier of the module, library, or package that is instrumented.


### PR DESCRIPTION
Renames to be closer to the Java version. Both names don't reflect common types in .NET so I think this should be fine and a bit more readable. `Field` from the Key-Value PR will also not contain a prefix.

I'll merge this if there are no complaints by Wednesday.