### PR TITLE
Propagation improvements, Tests

### DIFF
--- a/OpenTracing.sln
+++ b/OpenTracing.sln
@@ -18,6 +18,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "OpenTracing", "src\OpenTrac
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "OpenTracing.BasicTracer", "src\OpenTracing.BasicTracer\OpenTracing.BasicTracer.xproj", "{F6B85753-F584-4253-A96B-F3666FC64D17}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "OpenTracing.Tests", "test\OpenTracing.Tests\OpenTracing.Tests.xproj", "{F82B4191-F9D1-4656-8585-840E6BA045DD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,6 +38,10 @@ Global
 		{F6B85753-F584-4253-A96B-F3666FC64D17}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F6B85753-F584-4253-A96B-F3666FC64D17}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F6B85753-F584-4253-A96B-F3666FC64D17}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F82B4191-F9D1-4656-8585-840E6BA045DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F82B4191-F9D1-4656-8585-840E6BA045DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F82B4191-F9D1-4656-8585-840E6BA045DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F82B4191-F9D1-4656-8585-840E6BA045DD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -44,5 +50,6 @@ Global
 		{269A7820-7439-45B5-92EF-A31B07534563} = {FC8B6803-6F66-4F1E-9034-5564B2D4FF9C}
 		{60B9BDE0-8203-46C9-9373-E06FC82CECB3} = {CA88CFB0-F5DF-411B-B083-D54819E9414F}
 		{F6B85753-F584-4253-A96B-F3666FC64D17} = {CA88CFB0-F5DF-411B-B083-D54819E9414F}
+		{F82B4191-F9D1-4656-8585-840E6BA045DD} = {FC8B6803-6F66-4F1E-9034-5564B2D4FF9C}
 	EndGlobalSection
 EndGlobal

--- a/src/OpenTracing.BasicTracer/Propagation/TextMapCarrierHandler.cs
+++ b/src/OpenTracing.BasicTracer/Propagation/TextMapCarrierHandler.cs
@@ -7,13 +7,13 @@ namespace OpenTracing.BasicTracer.Propagation
     {
         public void MapContextToCarrier(SpanContext context, ITextMap carrier)
         {
-            carrier.Add(BaggageKeys.TraceId, context.TraceId.ToString());
-            carrier.Add(BaggageKeys.SpanId, context.SpanId.ToString());
-            carrier.Add(BaggageKeys.Sampled, context.Sampled.ToString());
+            carrier.Set(BaggageKeys.TraceId, context.TraceId.ToString());
+            carrier.Set(BaggageKeys.SpanId, context.SpanId.ToString());
+            carrier.Set(BaggageKeys.Sampled, context.Sampled.ToString());
 
             foreach (var kvp in context.GetBaggageItems())
             {
-                carrier.Add(BaggageKeys.BaggagePrefix + kvp.Key, kvp.Value);
+                carrier.Set(BaggageKeys.BaggagePrefix + kvp.Key, kvp.Value);
             }
         }
 

--- a/src/OpenTracing/Extensions/FormatBinaryExtensions.cs
+++ b/src/OpenTracing/Extensions/FormatBinaryExtensions.cs
@@ -7,7 +7,7 @@ namespace OpenTracing
     /// Contains <see cref="ITracer.Inject"/> and <see cref="ITracer.Extract"/> extension methods for types 
     /// from the .NET framework which have to be sent using the format <see cref="Formats.Binary"/>.
     /// </summary>
-    public static class FormatBinaryTracerExtensions
+    public static class FormatBinaryExtensions
     {
         /// <summary>
         /// This takes the <paramref name="span"/>s SpanContext and injects it for propagation within the given <paramref name="data"/>

--- a/src/OpenTracing/Extensions/FormatHttpHeadersExtensions.cs
+++ b/src/OpenTracing/Extensions/FormatHttpHeadersExtensions.cs
@@ -62,7 +62,7 @@ namespace OpenTracing
                 throw new ArgumentNullException(nameof(tracer));
             }
 
-            tracer.Inject(spanContext, Formats.HttpHeaders, new HttpHeadersCarrier(headers));
+            tracer.Inject(spanContext, Formats.HttpHeaders, new SystemNetHttpHeadersCarrier(headers));
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace OpenTracing
                 throw new ArgumentNullException(nameof(tracer));
             }
 
-            return tracer.Extract(Formats.HttpHeaders, new HttpHeadersCarrier(headers));
+            return tracer.Extract(Formats.HttpHeaders, new SystemNetHttpHeadersCarrier(headers));
         }
 
         /// <summary>

--- a/src/OpenTracing/Propagation/DictionaryCarrier.cs
+++ b/src/OpenTracing/Propagation/DictionaryCarrier.cs
@@ -31,7 +31,7 @@ namespace OpenTracing.Propagation
             return _payload.TryGetValue(key, out value) ? value : null;
         }
 
-        public void Add(string key, string value)
+        public void Set(string key, string value)
         {
             _payload[key] = value;
         }

--- a/src/OpenTracing/Propagation/Format.cs
+++ b/src/OpenTracing/Propagation/Format.cs
@@ -6,7 +6,7 @@ namespace OpenTracing.Propagation
     /// Format instances control the behavior of <see cref="ITracer.Inject" /> and <see cref="ITracer.Extract" /> 
     /// (and also constrain the type of the carrier parameter to same).
     /// </summary>
-    public class Format<TCarrier> : IEquatable<Format<TCarrier>>
+    public struct Format<TCarrier>
     {
         /// <summary>
         /// The unique name for this format.
@@ -21,39 +21,6 @@ namespace OpenTracing.Propagation
             }
 
             Name = name;
-        }
-    
-        /// <summary>
-        /// Two format instances are equal when they have the same <see cref="Name" />.
-        /// </summary>
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
-
-            return Equals(obj as Format<TCarrier>);
-        }
-
-        /// <summary>
-        /// Two format instances are equal when they have the same <see cref="Name" />.
-        /// </summary>
-        public bool Equals(Format<TCarrier> other)
-        {
-            if (other == null)
-            {
-                return false;
-            }
-
-            return string.Equals(Name, other.Name);
-        }
-
-        /// <summary>
-        /// Two format instances are equal when they have the same <see cref="Name" />.
-        /// </summary>
-        public override int GetHashCode()
-        {
-            return Name.GetHashCode();
         }
     }
 }

--- a/src/OpenTracing/Propagation/ITextMap.cs
+++ b/src/OpenTracing/Propagation/ITextMap.cs
@@ -3,13 +3,15 @@ using System.Collections.Generic;
 namespace OpenTracing.Propagation
 {
     /// <summary>
-    /// <see cref="ITextMapCarrier"/> is a built-in carrier for <see cref="ITracer.Inject"/> and <see cref="ITracer.Extract"/>. 
-    /// TextMap implementations allow Tracers to read and write key:value String pairs from arbitrary underlying sources of data.
+    /// <see cref="ITextMap"/> is a built-in carrier for <see cref="ITracer.Inject"/> and <see cref="ITracer.Extract"/>. 
+    /// ITextMap implementations allow Tracers to read and write key:value String pairs from arbitrary underlying sources of data.
     /// </summary>
     public interface ITextMap
     {
         /// <summary>
-        /// Returns all key:value pairs from the underlying source.
+        /// <para>Returns all key:value pairs from the underlying source.</para>
+        /// <para>Note that for some Formats, the iterator may include entries that
+        /// were never injected by a Tracer implementation (e.g., unrelated HTTP headers).</para>
         /// </summary>
         IEnumerable<KeyValuePair<string, string>> GetEntries();
 
@@ -17,12 +19,13 @@ namespace OpenTracing.Propagation
         /// Returns the key's value from the underlying source, or null if the key doesn't exist.
         /// </summary>
         /// <param name="key">The key for which a value should be returned.</param>
-        /// <returns></returns>
         string Get(string key);
 
         /// <summary>
-        /// Adds a key:value pair into the underlying source.
+        /// Adds a key:value pair into the underlying source. If the source already contains the key, the value will be overwritten.
         /// </summary>
-        void Add(string key, string value);
+        /// <param name="key">A string, possibly with constraints dictated by the particular Format this <see cref="ITextMap"/> is paired with.</param>
+        /// <param name="value">A String, possibly with constraints dictated by the particular Format this <see cref="ITextMap"/> is paired with.</param>
+        void Set(string key, string value);
     }
 }

--- a/src/OpenTracing/Propagation/SystemNetHttpHeadersCarrier.cs
+++ b/src/OpenTracing/Propagation/SystemNetHttpHeadersCarrier.cs
@@ -10,14 +10,11 @@ namespace OpenTracing.Propagation
     /// <remarks>
     /// <see cref="HttpHeaders"/> is a multi-value dictionary. Since most other platforms represent http headers as regular
     /// dictionaries, this carrier represents it as a regular dictionary to tracer implementations.</remarks>
-    public class HttpHeadersCarrier : ITextMap
+    public class SystemNetHttpHeadersCarrier : ITextMap
     {
-        // TODO should this class be internal/private? It's name is misleading because this only works with the .NET framework class "HttpHeaders"
-        // (The headers from ASP.NET Core are not compatible with this class.)
-
         private readonly HttpHeaders _headers;
 
-        public HttpHeadersCarrier(HttpHeaders headers)
+        public SystemNetHttpHeadersCarrier(HttpHeaders headers)
         {
             if (headers == null)
             {
@@ -47,8 +44,13 @@ namespace OpenTracing.Propagation
             return null;
         }
 
-        public void Add(string key, string value)
+        public void Set(string key, string value)
         {
+            if (_headers.Contains(key))
+            {
+                _headers.Remove(key);
+            }
+
             _headers.Add(key, value);
         }
     }

--- a/test/OpenTracing.Tests/DictionaryCarrierTests.cs
+++ b/test/OpenTracing.Tests/DictionaryCarrierTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTracing.Propagation;
+using Xunit;
+
+namespace OpenTracing.Tests
+{
+    public class DictionaryCarrierTests
+    {
+        private IDictionary<string, string> GetDictionary(int items)
+        {
+            var data = new Dictionary<string, string>();
+
+            for (int i = 1; i <= items; i++)
+            {
+                data.Add($"key{i}", $"value{i}");
+            }
+
+            return data;
+        }
+
+        [Fact]
+        public void Ctor_throws_if_data_missing()
+        {
+            IDictionary<string, string> data = null;
+
+            Assert.Throws<ArgumentNullException>(() => new DictionaryCarrier(data));
+        }
+
+        [Fact]
+        public void GetEntries_returns_all_entries()
+        {
+            var data = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" },
+                { "key3", "value3" }
+            };
+            var carrier = new DictionaryCarrier(data);
+
+            var resultEntries = carrier.GetEntries();
+
+            Assert.True(resultEntries.SequenceEqual(data));
+        }
+
+        [Fact]
+        public void Get_throws_if_key_missing()
+        {
+            var data = new Dictionary<string, string>
+            {
+                { "key1", "value1" }
+            };
+            var carrier = new DictionaryCarrier(data);
+
+            Assert.Throws<ArgumentNullException>(() => carrier.Get(null));
+        }
+
+        [Fact]
+        public void Get_returns_null_if_key_is_empty()
+        {
+            var data = new Dictionary<string, string>
+            {
+                { "key1", "value1" }
+            };
+            var carrier = new DictionaryCarrier(data);
+
+            Assert.Null(carrier.Get(""));
+        }
+
+        [Fact]
+        public void Get_returns_null_if_key_is_not_found()
+        {
+            var data = new Dictionary<string, string>
+            {
+                { "key1", "value1" }
+            };
+            var carrier = new DictionaryCarrier(data);
+
+            Assert.Null(carrier.Get("invalid"));
+        }
+
+        [Fact]
+        public void Get_returns_correct_value()
+        {
+            var data = new Dictionary<string, string>
+            {
+                { "key1", "value1" },
+                { "key2", "value2" },
+                { "key3", "value3" }
+            };
+            var carrier = new DictionaryCarrier(data);
+
+            var result = carrier.Get("key2");
+
+            Assert.Equal("value2", result);
+        }
+
+        [Fact]
+        public void Set_throws_if_key_missing()
+        {
+            var data = new Dictionary<string, string> { { "key1", "value1" } };
+            var carrier = new DictionaryCarrier(data);
+
+            Assert.Throws<ArgumentNullException>(() => carrier.Set(null, "value"));
+        }
+
+        [Fact]
+        public void Set_succeeds_if_value_null()
+        {
+            var data = new Dictionary<string, string> { { "key1", "value1" } };
+            var carrier = new DictionaryCarrier(data);
+
+            carrier.Set("key2", null);
+
+            Assert.Equal(2, data.Count);
+        }
+
+        [Fact]
+        public void Set_succeeds_if_new_key()
+        {
+            var data = new Dictionary<string, string> { { "key1", "value1" } };
+            var carrier = new DictionaryCarrier(data);
+
+            carrier.Set("key2", "value2");
+
+            Assert.Equal(2, data.Count);
+        }
+
+        [Fact]
+        public void Set_overwrites_existing_key()
+        {
+            var data = new Dictionary<string, string> { { "key1", "value1" } };
+            var carrier = new DictionaryCarrier(data);
+
+            carrier.Set("key1", "value2");
+
+            Assert.Equal(1, data.Count);
+            Assert.Equal("value2", data["key1"]);
+        }
+    }
+}

--- a/test/OpenTracing.Tests/FormatTests.cs
+++ b/test/OpenTracing.Tests/FormatTests.cs
@@ -1,0 +1,44 @@
+using OpenTracing.Propagation;
+using Xunit;
+
+namespace OpenTracing.Tests
+{
+    public class FormatTests
+    {
+        [Fact]
+        public void Formats_with_different_names_but_same_type_are_different()
+        {
+            var format1 = new Format<ITextMap>("format1");
+            var format2 = new Format<ITextMap>("format2");
+
+            Assert.NotEqual(format1, format2);
+        }
+
+        [Fact]
+        public void Formats_with_different_names_and_different_types_are_different()
+        {
+            var format1 = new Format<ITextMap>("format1");
+            var format2 = new Format<string>("format2");
+
+            Assert.False(format1.Equals(format2));
+        }
+
+        [Fact]
+        public void Formats_with_different_types_but_same_name_are_different()
+        {
+            var format1 = new Format<ITextMap>("format");
+            var format2 = new Format<string>("format");
+
+            Assert.False(format1.Equals(format2));
+        }
+
+        [Fact]
+        public void Formats_with_same_name_and_same_type_are_equal()
+        {
+            var format1 = new Format<ITextMap>("format");
+            var format2 = new Format<ITextMap>("format");
+
+            Assert.Equal(format1, format2);
+        }
+    }
+}

--- a/test/OpenTracing.Tests/OpenTracing.Tests.xproj
+++ b/test/OpenTracing.Tests/OpenTracing.Tests.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>f82b4191-f9d1-4656-8585-840e6ba045dd</ProjectGuid>
+    <RootNamespace>OpenTracing.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/OpenTracing.Tests/project.json
+++ b/test/OpenTracing.Tests/project.json
@@ -1,0 +1,25 @@
+{
+  "testRunner": "xunit",
+  
+  "dependencies": {
+    "OpenTracing": "0.9.0-*",
+
+    "xunit": "2.2.0-beta2-build3300",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
+  },
+
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      }
+    }
+  },
+
+  "buildOptions": {
+    "warningsAsErrors": true
+  }
+}


### PR DESCRIPTION
This PR does the following things:

* `Format` is now a struct instead of a class. Value comparison for structs is done by comparing each field so this is less code.
* Adds a new Test project with tests for `Format` equality and `DictionaryCarrier` behavior. It's a new project because the one for BasicTracer will be moved to the other repository.
* `ITextMap.Add` was renamed to `Set` because the Java equivalent `Put` means that keys are replaced if they already exist. `Set` is the common name in C# for this.
* Renames `HttpHeadersCarrier` to `SystemNetHttpHeadersCarrier`. This makes clear that this is not the base class but instead for one actual headers type. Users will usually not see this because they call the extension methods (which still have to be discussed in a separate issue)