### PR TITLE
TagExtensions for ISpanBuilder and ISpan

### DIFF
--- a/src/OpenTracing/Extensions/SpanTagExtensions.cs
+++ b/src/OpenTracing/Extensions/SpanTagExtensions.cs
@@ -10,7 +10,7 @@ namespace OpenTracing
     /// <summary>
     /// Typed extension methods for common tags.
     /// </summary>
-    public static class SpanTagExtensions
+    public static class TagExtensions
     {
         /// <summary>
         ///  "span.kind" hints at the relationship between spans, e.g. client/server.
@@ -23,9 +23,25 @@ namespace OpenTracing
         /// <summary>
         ///  "span.kind" hints at the relationship between spans, e.g. client/server.
         /// </summary>
+        public static ISpanBuilder WithTagSpanKind(this ISpanBuilder builder, string spanKind)
+        {
+            return WithTag(builder, Tags.SpanKind, spanKind);
+        }
+
+        /// <summary>
+        ///  "span.kind" hints at the relationship between spans, e.g. client/server.
+        /// </summary>
         public static ISpan SetTagSpanKindServer(this ISpan span)
         {
-            return SetTagSpanKind(span, "server");
+            return SetTagSpanKind(span, Tags.SpanKindServer);
+        }
+
+        /// <summary>
+        ///  "span.kind" hints at the relationship between spans, e.g. client/server.
+        /// </summary>
+        public static ISpanBuilder WithTagSpanKindServer(this ISpanBuilder builder)
+        {
+            return WithTagSpanKind(builder, Tags.SpanKindServer);
         }
 
         /// <summary>
@@ -33,7 +49,15 @@ namespace OpenTracing
         /// </summary>
         public static ISpan SetTagSpanKindClient(this ISpan span)
         {
-            return SetTagSpanKind(span, "client");
+            return SetTagSpanKind(span, Tags.SpanKindClient);
+        }
+
+        /// <summary>
+        ///  "span.kind" hints at the relationship between spans, e.g. client/server.
+        /// </summary>
+        public static ISpanBuilder WithTagSpanKindClient(this ISpanBuilder builder)
+        {
+            return WithTagSpanKind(builder, Tags.SpanKindClient);
         }
 
         /// <summary>
@@ -44,7 +68,13 @@ namespace OpenTracing
             return SetTag(span, Tags.Component, component);
         }
 
-
+        /// <summary>
+        ///  "component" is a low-cardinality identifier of the module, library, or package that is instrumented.
+        /// </summary>
+        public static ISpanBuilder WithTagComponent(this ISpanBuilder builder, string component)
+        {
+            return WithTag(builder, Tags.Component, component);
+        }
 
         /// <summary>
         ///  "http.url" records the url of the incoming request.
@@ -57,9 +87,25 @@ namespace OpenTracing
         /// <summary>
         ///  "http.url" records the url of the incoming request.
         /// </summary>
+        public static ISpanBuilder WithTagHttpUrl(this ISpanBuilder builder, string httpUrl)
+        {
+            return WithTag(builder, Tags.HttpUrl, httpUrl);
+        }
+
+        /// <summary>
+        ///  "http.url" records the url of the incoming request.
+        /// </summary>
         public static ISpan SetTagHttpUrl(this ISpan span, Uri httpUrl)
         {
             return SetTag(span, Tags.HttpUrl, httpUrl?.ToString());
+        }
+
+        /// <summary>
+        ///  "http.url" records the url of the incoming request.
+        /// </summary>
+        public static ISpanBuilder WithTagHttpUrl(this ISpanBuilder builder, Uri httpUrl)
+        {
+            return WithTag(builder, Tags.HttpUrl, httpUrl?.ToString());
         }
 
         /// <summary>
@@ -73,9 +119,25 @@ namespace OpenTracing
         /// <summary>
         ///  "http.method" records the method of the incoming request.
         /// </summary>
+        public static ISpanBuilder WithTagHttpMethod(this ISpanBuilder builder, string httpMethod)
+        {
+            return WithTag(builder, Tags.HttpUrl, httpMethod);
+        }
+
+        /// <summary>
+        ///  "http.method" records the method of the incoming request.
+        /// </summary>
         public static ISpan SetTagHttpMethod(this ISpan span, HttpMethod httpMethod)
         {
             return SetTag(span, Tags.HttpUrl, httpMethod?.Method);
+        }
+
+        /// <summary>
+        ///  "http.method" records the method of the incoming request.
+        /// </summary>
+        public static ISpanBuilder WithTagHttpMethod(this ISpanBuilder builder, HttpMethod httpMethod)
+        {
+            return WithTag(builder, Tags.HttpUrl, httpMethod?.Method);
         }
 
         /// <summary>
@@ -89,9 +151,25 @@ namespace OpenTracing
         /// <summary>
         ///  "http.status_code" records the http status code of the response.
         /// </summary>
+        public static ISpanBuilder WithTagHttpStatusCode(this ISpanBuilder builder, int httpStatusCode)
+        {
+            return WithTag(builder, Tags.HttpStatusCode, httpStatusCode);
+        }
+
+        /// <summary>
+        ///  "http.status_code" records the http status code of the response.
+        /// </summary>
         public static ISpan SetTagHttpStatusCode(this ISpan span, HttpStatusCode httpStatusCode)
         {
             return SetTag(span, Tags.HttpStatusCode, httpStatusCode);
+        }
+
+        /// <summary>
+        ///  "http.status_code" records the http status code of the response.
+        /// </summary>
+        public static ISpanBuilder WithTagHttpStatusCode(this ISpanBuilder builder, HttpStatusCode httpStatusCode)
+        {
+            return WithTag(builder, Tags.HttpStatusCode, httpStatusCode);
         }
 
         /// <summary>
@@ -103,11 +181,27 @@ namespace OpenTracing
         }
 
         /// <summary>
+        /// "peer.hostname" records the host name of the peer.
+        /// </summary>
+        public static ISpanBuilder WithTagPeerHostname(this ISpanBuilder builder, string peerHostname)
+        {
+            return WithTag(builder, Tags.PeerHostname, peerHostname);
+        }
+
+        /// <summary>
         ///  "peer.ipv4" records IPv4 host address of the peer.
         /// </summary>
         public static ISpan SetTagPeerIpV4(this ISpan span, string peerIpV4)
         {
             return SetTag(span, Tags.PeerIpV4, peerIpV4);
+        }
+
+        /// <summary>
+        ///  "peer.ipv4" records IPv4 host address of the peer.
+        /// </summary>
+        public static ISpanBuilder WithTagPeerIpV4(this ISpanBuilder builder, string peerIpV4)
+        {
+            return WithTag(builder, Tags.PeerIpV4, peerIpV4);
         }
 
         /// <summary>
@@ -118,7 +212,19 @@ namespace OpenTracing
             return SetTag(span, Tags.PeerIpV6, peerIpV6);
         }
 
+        /// <summary>
+        ///  "peer.ipv6" records the IPv6 host address of the peer.
+        /// </summary>
+        public static ISpanBuilder WithTagPeerIpV6(this ISpanBuilder builder, string peerIpV6)
+        {
+            return WithTag(builder, Tags.PeerIpV6, peerIpV6);
+        }
+
 #if NETSTANDARD1_3
+        
+        /// <summary>
+        /// Sets either "peer.ipv4" or "peer.ipv6".
+        /// </summary>
         public static ISpan SetTagPeerIp(this ISpan span, IPAddress peerIp)
         {
             if (peerIp == null)
@@ -139,6 +245,31 @@ namespace OpenTracing
                 throw new NotSupportedException($"{nameof(peerIp.AddressFamily)} value '{peerIp.AddressFamily}' is not supported");
             }
         }
+
+        /// <summary>
+        /// Sets either "peer.ipv4" or "peer.ipv6".
+        /// </summary>
+        public static ISpanBuilder WithTagPeerIp(this ISpanBuilder builder, IPAddress peerIp)
+        {
+            if (peerIp == null)
+            {
+                throw new ArgumentNullException(nameof(peerIp));
+            }
+
+            if (peerIp.AddressFamily == AddressFamily.InterNetwork)
+            {
+                return WithTag(builder, Tags.PeerIpV4, peerIp.ToString());
+            }
+            else if (peerIp.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                return WithTag(builder, Tags.PeerIpV6, peerIp.ToString());
+            }
+            else
+            {
+                throw new NotSupportedException($"{nameof(peerIp.AddressFamily)} value '{peerIp.AddressFamily}' is not supported");
+            }
+        }
+
 #endif
 
         /// <summary>
@@ -150,11 +281,27 @@ namespace OpenTracing
         }
 
         /// <summary>
+        ///  "peer.port" records the port number of the peer.
+        /// </summary>
+        public static ISpanBuilder WithTagPeerPort(this ISpanBuilder builder, int peerPort)
+        {
+            return WithTag(builder, Tags.PeerPort, peerPort);
+        }
+
+        /// <summary>
         ///  "peer.service" records the service name of the peer.
         /// </summary>
         public static ISpan SetTagPeerService(this ISpan span, string peerService)
         {
             return SetTag(span, Tags.PeerService, peerService);
+        }
+
+        /// <summary>
+        ///  "peer.service" records the service name of the peer.
+        /// </summary>
+        public static ISpanBuilder WithTagPeerService(this ISpanBuilder builder, string peerService)
+        {
+            return WithTag(builder, Tags.PeerService, peerService);
         }
 
         /// <summary>
@@ -166,6 +313,14 @@ namespace OpenTracing
         }
 
         /// <summary>
+        ///  "sampling.priority" determines the priority of sampling this Span.
+        /// </summary>
+        public static ISpanBuilder WithTagSamplingPriority(this ISpanBuilder builder, int samplingPriority)
+        {
+            return WithTag(builder, Tags.SamplingPriority, samplingPriority);
+        }
+
+        /// <summary>
         /// "error" indicates whether a Span ended in an error state.
         /// </summary>
         public static ISpan SetTagError(this ISpan span, bool error = true)
@@ -173,6 +328,23 @@ namespace OpenTracing
             return SetTag(span, Tags.Error, error);
         }
 
+        /// <summary>
+        /// "error" indicates whether a Span ended in an error state.
+        /// </summary>
+        public static ISpanBuilder WithTagError(this ISpanBuilder builder, bool error = true)
+        {
+            return WithTag(builder, Tags.Error, error);
+        }
+
+        private static ISpanBuilder WithTag(ISpanBuilder builder, string key, object value)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return builder.WithTag(key, value);
+        }
 
         private static ISpan SetTag(ISpan span, string key, object value)
         {

--- a/src/OpenTracing/Tags.cs
+++ b/src/OpenTracing/Tags.cs
@@ -19,6 +19,16 @@ namespace OpenTracing
         public const string SpanKind = "span.kind";
 
         /// <summary>
+        /// A constant for setting the span kind to indicate that it represents a client span.
+        /// </summary>
+        public const string SpanKindClient = "client";
+
+        /// <summary>
+        /// A constant for setting the span kind to indicate that it represents a server span.
+        /// </summary>
+        public const string SpanKindServer = "server";
+
+        /// <summary>
         ///  "http.url" records the url of the incoming request.
         /// </summary>
         public const string HttpUrl = "http.url";


### PR DESCRIPTION
This PR should serve as a discussion point about whether or not we should use extension methods for known tags. Just as a recap: "Extension methods" in C# do not change the original contract of a type (`ISpanBuilder`, `ISpan` in this case). They are just syntactical sugar for users and they will be replaced with regular static calls by the compiler. In other words, the only reason for them is to offer a simpler/better experience for users.

This is different to what Java does because afaik Java does not have extension methods. I really like extension methods because they offer great Intellisense for users and people can easily extend it with their own extension methods to keep a consistent API.

Of course, they could also live in a separate library (e.g. opentracing-contrib) but since they are so fundamental, I don't like that basically everybody would have to add two libraries.

The current code already contains `SetTag*` extensions for `ISpan`, this PR adds the same extensions for `ISpanBuilder`.

Using extension methods for known tags would allow users do write the following code:

```csharp
// Using ISpanBuilder
var span = tracer.BuildSpan("get_account")
  .WithTagComponent("ASP.NET Core")
  .WithTagSpanKindServer()
  .WithTagHttpUrl(request.Path)
  .WithTagHttpMethod(request.Method)
  .WithTag("custom", "value")
  .Start();

// Using ISpanBuilder + ISpan
var span = tracer.BuildSpan("get_account")
  .WithTagSpanKindServer()
  .Start();

span
  .SetTagHttpUrl(request.Path)
  .SetTagHttpStatusCode(response.StatusCode)
  .SetTag("custom", "value");

// Syntax without extension methods
var span = tracer.BuildSpan("get_account")
  .WithTag(Tags.Component, "ASP.NET Core")
  .WithTag(Tags.SpanKind, Tags.SpanKindServer)
  .Start();

span
  .SetTag(Tags.HttpStatusCode, (int)response.StatusCode);
```

If you agree to keep them, my main question is:
* Should we remove "Tag" from the names? Example: Should it be `.SetComponent("ASP.NET Core")` instead of `SetTagComponent("ASP.NET Core")`?
  * The advantage is a more readable API
  * Disadvantage is that it might not be clear to the user that this will be saved as a tag (although that might not be important for the user anyway)
  * It could also lead to conflicts should we decide to add a regular `SetComponent` method in the future for whatever reason.

Open tasks:
- [ ] Decision: Should we use Tag extension methods at all?
- [ ] Should we keep "Tag" in the name?
- [ ] rename file `SpanTagExtensions.cs` to `TagExtensions.cs` (the diff would have been awful if I had done this in one step)