### PR TITLE
Restrict tag types to bool/double/string like in Java

### DIFF
--- a/src/OpenTracing/ISpan.cs
+++ b/src/OpenTracing/ISpan.cs
@@ -24,13 +24,25 @@ namespace OpenTracing
         /// Adds a tag to the Span.
         /// </summary>
         /// <param name="key">If there is a pre-existing tag set for <paramref name="key"/>, it is overwritten.</param>
-        /// <param name="value">
-        /// Tag values can be numeric types, strings, or bools. The behavior of other tag value types is undefined 
-        /// at the OpenTracing level. If a tracing system does not know how to handle a particular value type, it
-        /// may ignore the tag, but shall not panic.
-        /// </param>
+        /// <param name="value">The value to be stored.</param>
         /// <returns>The current <see cref="ISpan"/> instance for chaining.</returns>
-        ISpan SetTag(string key, object value);
+        ISpan SetTag(string key, bool value);
+
+        /// <summary>
+        /// Adds a tag to the Span.
+        /// </summary>
+        /// <param name="key">If there is a pre-existing tag set for <paramref name="key"/>, it is overwritten.</param>
+        /// <param name="value">The value to be stored.</param>
+        /// <returns>The current <see cref="ISpan"/> instance for chaining.</returns>
+        ISpan SetTag(string key, double value);
+
+        /// <summary>
+        /// Adds a tag to the Span.
+        /// </summary>
+        /// <param name="key">If there is a pre-existing tag set for <paramref name="key"/>, it is overwritten.</param>
+        /// <param name="value">The value to be stored.</param>
+        /// <returns>The current <see cref="ISpan"/> instance for chaining.</returns>
+        ISpan SetTag(string key, string value);
 
         /// <summary>
         /// Records an event with optional payload data for this Span.

--- a/src/OpenTracing/ISpanBuilder.cs
+++ b/src/OpenTracing/ISpanBuilder.cs
@@ -32,14 +32,33 @@ namespace OpenTracing
         /// May be called multiple times to represent multiple such references.
         /// </summary>
         /// <param name="referenceType">The reference type, typically one of the constants defined in References.</param>
-        /// <param name="referencedContext">The <see cref="ISpanContext"/> being referenced; 
+        /// <param name="referencedContext">The <see cref="ISpanContext"/> being referenced;
         /// e.g., for a References.ChildOf referenceType, the referencedContext is the parent.</param>
         ISpanBuilder AddReference(string referenceType, ISpanContext referencedContext);
 
         /// <summary>
-        /// Same as <see cref="ISpan.SetTag" />, but for the span being built.
+        /// Adds a tag to the Span.
         /// </summary>
-        ISpanBuilder WithTag(string key, object value);
+        /// <param name="key">If there is a pre-existing tag set for <paramref name="key"/>, it is overwritten.</param>
+        /// <param name="value">The value to be stored.</param>
+        /// <returns>The current <see cref="ISpan"/> instance for chaining.</returns>
+        ISpanBuilder WithTag(string key, bool value);
+
+        /// <summary>
+        /// Adds a tag to the Span.
+        /// </summary>
+        /// <param name="key">If there is a pre-existing tag set for <paramref name="key"/>, it is overwritten.</param>
+        /// <param name="value">The value to be stored.</param>
+        /// <returns>The current <see cref="ISpan"/> instance for chaining.</returns>
+        ISpanBuilder WithTag(string key, double value);
+
+        /// <summary>
+        /// Adds a tag to the Span.
+        /// </summary>
+        /// <param name="key">If there is a pre-existing tag set for <paramref name="key"/>, it is overwritten.</param>
+        /// <param name="value">The value to be stored.</param>
+        /// <returns>The current <see cref="ISpan"/> instance for chaining.</returns>
+        ISpanBuilder WithTag(string key, string value);
 
         /// <summary>
         /// Specify a timestamp of when the Span was started.

--- a/src/OpenTracing/NullTracer/NullSpan.cs
+++ b/src/OpenTracing/NullTracer/NullSpan.cs
@@ -17,7 +17,17 @@ namespace OpenTracing.NullTracer
             return this;
         }
 
-        public ISpan SetTag(string key, object value)
+        public ISpan SetTag(string key, bool value)
+        {
+            return this;
+        }
+
+        public ISpan SetTag(string key, double value)
+        {
+            return this;
+        }
+
+        public ISpan SetTag(string key, string value)
         {
             return this;
         }

--- a/src/OpenTracing/NullTracer/NullSpanBuilder.cs
+++ b/src/OpenTracing/NullTracer/NullSpanBuilder.cs
@@ -40,7 +40,17 @@ namespace OpenTracing.NullTracer
             return this;
         }
 
-        public ISpanBuilder WithTag(string key, object value)
+        public ISpanBuilder WithTag(string key, bool value)
+        {
+            return this;
+        }
+
+        public ISpanBuilder WithTag(string key, double value)
+        {
+            return this;
+        }
+
+        public ISpanBuilder WithTag(string key, string value)
         {
             return this;
         }


### PR DESCRIPTION
I'm writing my first instrumentation for this library and I think, now that we no longer have extension methods on tags, it's way too easy to pass wrong types to `SetTag` and `WithTag`. Examples are passing enums instead of int, Uri instead of string, ...

This PR removes the string:object version and adds 3 overloads for `bool`/`string`/`double`. This is very similar to what Java has except that there isn't a base type for all numeric types in .NET. 

Using `double` will accept everything except `decimal`. If we would add an additional overload for `decimal`, then we have some types (e.g. `integer`) that would cast to both and the compiler will require an explicit cast. For this reason, I think it's ok to leave out decimal for now. If we need it, we probably need even more specific overloads to address the compiler errors.

I'll merge this in 3-4 days if there are no comments by then.