### PR TITLE
[WIP] In-process propagation with a simple `ITracer.ActiveSpan` property

### DIFF
--- a/src/OpenTracing/ISpanBuilder.cs
+++ b/src/OpenTracing/ISpanBuilder.cs
@@ -37,6 +37,11 @@ namespace OpenTracing
         ISpanBuilder AddReference(string referenceType, ISpanContext referencedContext);
 
         /// <summary>
+        /// When used, the newly created span will NOT inherit <see cref="ITracer.ActiveSpan"/> as a parent.
+        /// </summary>
+        ISpanBuilder IgnoreActiveSpan();
+
+        /// <summary>
         /// Adds a tag to the span.
         /// </summary>
         /// <param name="key">If there is a pre-existing tag set for <paramref name="key"/>, it is overwritten.</param>

--- a/src/OpenTracing/ITracer.cs
+++ b/src/OpenTracing/ITracer.cs
@@ -8,6 +8,13 @@ namespace OpenTracing
     public interface ITracer
     {
         /// <summary>
+        /// <para>Returns the currently active span. It is used for intra-process propagation and follows the async execution flow.</para>
+        /// <para>Any newly started span will inherit this span as a parent unless <see cref="ISpanBuilder.IgnoreActiveSpan"/>
+        /// is called before the span is started.</para>
+        /// </summary>
+        ISpan ActiveSpan { get; }
+
+        /// <summary>
         /// Returns a new <see cref="ISpanBuilder" /> for a span with the given <paramref name="operationName" />.
         /// </summary>
         /// <param name="operationName">The operation name of the span.</param>

--- a/src/OpenTracing/NullTracer/NullSpanBuilder.cs
+++ b/src/OpenTracing/NullTracer/NullSpanBuilder.cs
@@ -35,6 +35,11 @@ namespace OpenTracing.NullTracer
             return this;
         }
 
+        public ISpanBuilder IgnoreActiveSpan()
+        {
+            return this;
+        }
+
         public ISpanBuilder WithStartTimestamp(DateTime startTimestamp)
         {
             return this;

--- a/src/OpenTracing/NullTracer/NullTracer.cs
+++ b/src/OpenTracing/NullTracer/NullTracer.cs
@@ -10,6 +10,8 @@ namespace OpenTracing.NullTracer
         {
         }
 
+        public ISpan ActiveSpan => NullSpan.Instance;
+
         public ISpanBuilder BuildSpan(string operationName)
         {
             return NullSpanBuilder.Instance;


### PR DESCRIPTION
Related to #35. This PR shows a very simple contract for in-process propagation in C#.

It has the following properties:
* `ITracer.ActiveSpan` holds the currently active span. 
* Every new span will automatically get the active span as a parent.
* Opting out of this inheritance behavior is possible through `ISpanBuilder.IgnoreActiveSpan()`.
* There is no separate `IActiveSpan` because C# doesn't need the "Continuation" feature from the Java PR.
* This is a breaking change because the current usage would automatically activate spans. I don't think this is a problem though because I'm not even sure if anyone is using this library already :smile:

Since this library currently only holds contracts, these rules must be met by tracer implementations. We should discuss separately if there are any building blocks that should go into this library or a contrib project.

Things that are not possible with this right now:
* "Activating" an existing span that has been started with `ISpanBuilder.IgnoreActiveSpan()`
  * It should be discussed in #35 whether this is necessary.

Questions:
* Does a user need an API to access a span's parent? (e.g. `ISpan.Parent` or `ISpanContext.Parent`)

Usage:

```csharp
// Accessing the currently active span.
ISpan activeSpan = tracer.ActiveSpan;

// Starting a new span will automatically inherit an existing active span
// with a "child_of" reference and will "activate" itself.
ISpan span = tracer.BuildSpan("someWork").Start();
try
{
    HttpResponseMessage response = await httpClient.SendAsync(request);

    // C# automatically restores local variables in an async execution,
    // so this line doesn't even need to access `tracer.ActiveSpan`.
    span.SetTag(Tags.HttpStatusCode, response.StatusCode);
}
finally
{
    // Finish will revert "tracer.ActiveSpan" to its parent.
    span.Finish();
}

// The same can be achieved by using the IDisposable feature of ISpan and a "using" statement:
using (ISpan activeSpan = tracer.BuildSpan("someWork").Start())
{
    // (record data to `span`, call async methods, ...)
}

// If an `ActiveSpan` should NOT act as a parent for a newly started span
// a user can invoke `ISpanBuilder.IgnoreActiveSpan()` at `BuildSpan()` time, like so:
ISpan activeSpan = tracer.BuildSpan("someWork")
    .IgnoreActiveSpan()
    .Start();

```