### PR TITLE
Adds a (very) simple bash-based build-script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       dist: trusty
       sudo: required
       mono: none
-      dotnet: 1.0.3
+      dotnet: 1.0.4
 
 env:
   global:
@@ -14,6 +14,4 @@ env:
     - DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
 script:
-  - dotnet restore
-  - dotnet build -c Release
-  - dotnet test test/OpenTracing.Tests/OpenTracing.Tests.csproj -c Release --no-build
+  - ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# stop on first error
+set -e
+
+# arguments
+
+CONFIGURATION="Release"
+
+# validations
+
+if ! [ -x "$(command -v dotnet)" ]; then
+    echo "dotnet cli is not installed."
+    exit 1
+fi
+
+# tasks
+
+echo
+echo dotnet-restore
+echo ----------------------
+
+dotnet restore
+
+echo
+echo dotnet-build
+echo ----------------------
+
+dotnet build -c $CONFIGURATION --no-incremental
+
+echo
+echo dotnet-test
+echo ----------------------
+
+dotnet test test/OpenTracing.Tests/OpenTracing.Tests.csproj -c $CONFIGURATION --no-build


### PR DESCRIPTION
Fixes #38 

This is just a very simple bash build script. Note that it does NOT install the dotnet CLI. it must be installed according to https://www.microsoft.com/net/core

@TerribleDev Will this work for you?