### PR TITLE
Replace DateTime usage with DateTimeOffset

### DIFF
--- a/src/OpenTracing/ISpan.cs
+++ b/src/OpenTracing/ISpan.cs
@@ -101,7 +101,7 @@ namespace OpenTracing
         /// });
         /// </code>
         /// </example>
-        ISpan Log(DateTime timestamp, IEnumerable<KeyValuePair<string, object>> fields);
+        ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields);
 
         /// <summary>
         /// Record an event at the current timestamp.
@@ -117,7 +117,7 @@ namespace OpenTracing
         /// span's start timestamp.</param>
         /// <param name="eventName">The event value; often a stable identifier for a moment in the span lifecycle.</param>
         /// <returns>The current <see cref="ISpan"/> instance for chaining.</returns>
-        ISpan Log(DateTime timestamp, string eventName);
+        ISpan Log(DateTimeOffset timestamp, string eventName);
 
         /// <summary>
         /// <para>Sets a baggage item in the span (and its SpanContext) as a key/value pair.</para>
@@ -157,11 +157,8 @@ namespace OpenTracing
         /// this should be the last call made to the span instance, and to do otherwise
         /// leads to undefined behavior.
         /// </para>
-        /// <param name="finishTimestamp">
-        /// An explicit finish timestamp.
-        /// The behavior for kinds other than <see cref="DateTimeKind.Utc"/> is undefined.
-        /// </param>
+        /// <param name="finishTimestamp">An explicit finish timestamp.</param>
         /// </summary>
-        void Finish(DateTime finishTimestamp);
+        void Finish(DateTimeOffset finishTimestamp);
     }
 }

--- a/src/OpenTracing/ISpanBuilder.cs
+++ b/src/OpenTracing/ISpanBuilder.cs
@@ -71,11 +71,8 @@ namespace OpenTracing
         /// <summary>
         /// Specify a timestamp of when the span was started.
         /// </summary>
-        /// <param name="startTimestamp">
-        /// An explicit start timestamp for the span.
-        /// The behavior for kinds other than <see cref="DateTimeKind.Utc"/> is undefined.
-        /// </param>
-        ISpanBuilder WithStartTimestamp(DateTime startTimestamp);
+        /// <param name="startTimestamp">An explicit start timestamp for the span.</param>
+        ISpanBuilder WithStartTimestamp(DateTimeOffset startTimestamp);
 
         /// <summary>
         /// Returns the started span.

--- a/src/OpenTracing/NullTracer/NullSpan.cs
+++ b/src/OpenTracing/NullTracer/NullSpan.cs
@@ -43,7 +43,7 @@ namespace OpenTracing.NullTracer
             return this;
         }
 
-        public ISpan Log(DateTime timestamp, IEnumerable<KeyValuePair<string, object>> fields)
+        public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
         {
             return this;
         }
@@ -53,7 +53,7 @@ namespace OpenTracing.NullTracer
             return this;
         }
 
-        public ISpan Log(DateTime timestamp, string @event)
+        public ISpan Log(DateTimeOffset timestamp, string @event)
         {
             return this;
         }
@@ -72,7 +72,7 @@ namespace OpenTracing.NullTracer
         {
         }
 
-        public void Finish(DateTime finishTimestamp)
+        public void Finish(DateTimeOffset finishTimestamp)
         {
         }
 

--- a/src/OpenTracing/NullTracer/NullSpanBuilder.cs
+++ b/src/OpenTracing/NullTracer/NullSpanBuilder.cs
@@ -35,7 +35,7 @@ namespace OpenTracing.NullTracer
             return this;
         }
 
-        public ISpanBuilder WithStartTimestamp(DateTime startTimestamp)
+        public ISpanBuilder WithStartTimestamp(DateTimeOffset startTimestamp)
         {
             return this;
         }


### PR DESCRIPTION
See #42. I'll merge this in 2-3 days if there's no voice against it.

This is non-breaking for users (since there is an implicit cast from DateTime to DateTimeOffset) but it will break tracers (at compile-time). 