### PR TITLE
Inversion of control/separation of SpanBuilder syntax from implementation of ITracer

### DIFF
--- a/src/OpenTracing/ITracer.cs
+++ b/src/OpenTracing/ITracer.cs
@@ -1,4 +1,6 @@
 ﻿using OpenTracing.Propagation;
+using System;
+using System.Collections.Generic;
 
 namespace OpenTracing
 {
@@ -8,10 +10,17 @@ namespace OpenTracing
     public interface ITracer
     {
         /// <summary>
-        /// Returns a new <see cref="ISpanBuilder" /> for a span with the given <paramref name="operationName" />.
+        /// Starts a new Span
         /// </summary>
         /// <param name="operationName">The operation name of the span.</param>
-        ISpanBuilder BuildSpan(string operationName);
+        ISpan StartSpan(
+            string operationName,
+            IEnumerable<Tuple<string, ISpanContext>> references = null,
+            DateTimeOffset? explicitStartTime = null,
+            IEnumerable<KeyValuePair<string, string>> stringTags = null,
+            IEnumerable<KeyValuePair<string, bool>> boolTags = null,
+            IEnumerable<KeyValuePair<string, double>> doubleTags = null,
+            IEnumerable<KeyValuePair<string, int>> intTags = null);
 
         /// <summary>
         /// Inject a <see cref="ISpanContext"/> into a <paramref name="carrier"/> of a given type,

--- a/src/OpenTracing/TracerSpanBuilderExtensions.cs
+++ b/src/OpenTracing/TracerSpanBuilderExtensions.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace OpenTracing
+{
+    public static class TracerSpanBuilderExtensions
+    {
+        public static ISpanBuilder BuildSpan(ITracer tracer, string operationName)
+        {
+            return new SpanBuilder(tracer, operationName);
+        }
+
+        private sealed class SpanBuilder : ISpanBuilder
+        {
+            private readonly ITracer tracer;
+
+            private string operationName;
+            private ICollection<Tuple<string, ISpanContext>> references;
+            private DateTimeOffset? explicitStartTime;
+            private ICollection<KeyValuePair<string, string>> stringTags;
+            private ICollection<KeyValuePair<string, bool>> boolTags;
+            private ICollection<KeyValuePair<string, double>> doubleTags;
+            private ICollection<KeyValuePair<string, int>> intTags;
+
+            public SpanBuilder(ITracer tracer, string operationName)
+            {
+                this.tracer = tracer;
+                this.operationName = operationName;
+                this.references = new List<Tuple<string, ISpanContext>>();
+                this.stringTags = new List<KeyValuePair<string, string>>();
+                this.boolTags = new List<KeyValuePair<string, bool>>();
+                this.doubleTags = new List<KeyValuePair<string, double>>();
+                this.intTags = new List<KeyValuePair<string, int>>();
+            }
+
+            public ISpanBuilder AsChildOf(ISpan parent)
+            {
+                return this.AsChildOf(parent.Context);
+            }
+
+            public ISpanBuilder AsChildOf(ISpanContext parent)
+            {
+                return this.AddReference(References.ChildOf, parent);
+            }
+
+            public ISpanBuilder FollowsFrom(ISpan parent)
+            {
+                return this.FollowsFrom(parent.Context);
+            }
+
+            public ISpanBuilder FollowsFrom(ISpanContext parent)
+            {
+                return this.AddReference(References.FollowsFrom, parent);
+            }
+
+            public ISpanBuilder AddReference(string referenceType, ISpanContext referencedContext)
+            {
+                this.references.Add(Tuple.Create(referenceType, referencedContext));
+                return this;
+            }
+
+            public ISpanBuilder WithTag(string key, bool value)
+            {
+                this.boolTags.Add(new KeyValuePair<string, bool>(key, value));
+                return this;
+            }
+
+            public ISpanBuilder WithTag(string key, double value)
+            {
+                this.doubleTags.Add(new KeyValuePair<string, double>(key, value));
+                return this;
+            }
+
+            public ISpanBuilder WithTag(string key, int value)
+            {
+                this.intTags.Add(new KeyValuePair<string, int>(key, value));
+                return this;
+            }
+
+            public ISpanBuilder WithTag(string key, string value)
+            {
+                this.stringTags.Add(new KeyValuePair<string, string>(key, value));
+                return this;
+            }
+
+            public ISpanBuilder WithStartTimestamp(DateTimeOffset startTimestamp)
+            {
+                this.explicitStartTime = startTimestamp;
+                return this;
+            }
+
+            public ISpan Start()
+            {
+                return this.tracer.StartSpan(
+                    this.operationName,
+                    this.references,
+                    this.explicitStartTime,
+                    this.stringTags,
+                    this.boolTags,
+                    this.doubleTags,
+                    this.intTags);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The specification suggests a format similar to a SpanBuilder, but does not require such for implementations. Given that, perhaps it would be better to use a StartSpan (as the specification does detail) with it's optional parameters, and make SpanBuilder a thing that operates ON an ITrace. This would prevent every implementor from having to have quite similar implementations, and from a naïve implementor from accidentally emitting tags in the span builder before the span has started (it prevents implementors from having to deal with partially initialized objects).

Though, perhaps we do not like optional parameters, in which case there would be at least 3^2 overloads required, which would nearly mandate that we expose a builder directly from ITracer.