### PR TITLE
Target both netstandard1.0 and net45 to remove unneeded dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,10 +26,10 @@ echo
 echo dotnet-build
 echo ----------------------
 
-dotnet build -c $CONFIGURATION --no-incremental
+dotnet build -c $CONFIGURATION --no-incremental /p:NonWindowsBuild=true
 
 echo
 echo dotnet-test
 echo ----------------------
 
-dotnet test test/OpenTracing.Tests/OpenTracing.Tests.csproj -c $CONFIGURATION --no-build
+dotnet test test/OpenTracing.Tests/OpenTracing.Tests.csproj -c $CONFIGURATION --no-build /p:NonWindowsBuild=true

--- a/src/OpenTracing/OpenTracing.csproj
+++ b/src/OpenTracing/OpenTracing.csproj
@@ -8,4 +8,8 @@ For the time being, mild backwards-incompatible changes may be made without chan
     <PackageTags>opentracing;distributed-tracing;tracing;logging</PackageTags>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(NonWindowsBuild)' == 'true' ">
+      <TargetFrameworks>netstandard1.0;</TargetFrameworks>
+  </PropertyGroup>
+
 </Project>

--- a/src/OpenTracing/OpenTracing.csproj
+++ b/src/OpenTracing/OpenTracing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
     <Description>This library is a .NET implementation of the OpenTracing API. To fully understand this platform API, it's helpful to be familiar with the OpenTracing project and terminology more generally.
 
 For the time being, mild backwards-incompatible changes may be made without changing the major version number. As OpenTracing and opentracing-csharp mature, backwards compatibility will become more of a priority.</Description>

--- a/test/OpenTracing.Tests/OpenTracing.Tests.csproj
+++ b/test/OpenTracing.Tests/OpenTracing.Tests.csproj
@@ -4,6 +4,10 @@
     <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(NonWindowsBuild)' == 'true' ">
+      <TargetFrameworks>netcoreapp1.1;</TargetFrameworks>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenTracing\OpenTracing.csproj" />
   </ItemGroup>

--- a/test/OpenTracing.Tests/OpenTracing.Tests.csproj
+++ b/test/OpenTracing.Tests/OpenTracing.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When it is installed on a project targeting the full .Net framework, the `Opentracing` NuGet package because of its dependency on `NETStandard.Library` pulls a lot of dependencies that are not needed. It has no impact on the resulting executable however it requires downloading a lot of packages for nothing and when used with the old csproj format it clutters the `packages.config` with all the .net core packages. For example installing Opentracing in an empty project produces the following `packages.config` file:

```xml
<?xml version="1.0" encoding="utf-8"?>
<packages>
  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net461" />
  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
  <package id="NETStandard.Library" version="1.6.1" targetFramework="net461" />
  <package id="OpenTracing" version="0.10.0" targetFramework="net461" />
  <package id="System.AppContext" version="4.3.0" targetFramework="net461" />
  <package id="System.Collections" version="4.3.0" targetFramework="net461" />
  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net461" />
  <package id="System.Console" version="4.3.0" targetFramework="net461" />
  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net461" />
  <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net461" />
  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net461" />
  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net461" />
  <package id="System.Globalization" version="4.3.0" targetFramework="net461" />
  <package id="System.Globalization.Calendars" version="4.3.0" targetFramework="net461" />
  <package id="System.IO" version="4.3.0" targetFramework="net461" />
  <package id="System.IO.Compression" version="4.3.0" targetFramework="net461" />
  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net461" />
  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net461" />
  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
  <package id="System.Linq" version="4.3.0" targetFramework="net461" />
  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net461" />
  <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net461" />
  <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" />
  <package id="System.ObjectModel" version="4.3.0" targetFramework="net461" />
  <package id="System.Reflection" version="4.3.0" targetFramework="net461" />
  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net461" />
  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net461" />
  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net461" />
  <package id="System.Runtime" version="4.3.0" targetFramework="net461" />
  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net461" />
  <package id="System.Runtime.Handles" version="4.3.0" targetFramework="net461" />
  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net461" />
  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net461" />
  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net461" />
  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net461" />
  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net461" />
  <package id="System.Threading" version="4.3.0" targetFramework="net461" />
  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net461" />
  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net461" />
  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net461" />
  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net461" />
</packages>
```
To avoid this I suggest to target both netstandard1.0 and net45, that way when used with the full framework the net45 dll will be used and will not pull all these dependencies. The only downside I see with this approach is that AFAIK it prevents building the package on non Windows platforms. This will however have no consequences on non Windows users of the package, since the package will still be compatible with netstandard1.0.