### PR TITLE
finishSpanOnDispose instead of finishSpanOnClose

### DIFF
--- a/src/OpenTracing/IScopeManager.cs
+++ b/src/OpenTracing/IScopeManager.cs
@@ -23,15 +23,14 @@ namespace OpenTracing
 
         /// <summary>Make a <see cref="ISpan"/> instance active.</summary>
         /// <param name="span">The <see cref="ISpan"/> that should become the <see cref="Active"/></param>
-        /// <param name="finishSpanOnClose">
-        /// Whether span should automatically be finished when <see cref="IDisposable.Dispose"/> is
-        /// called
+        /// <param name="finishSpanOnDispose">
+        /// Whether span should automatically be finished when <see cref="IDisposable.Dispose"/> is called.
         /// </param>
         /// <returns>
         /// A <see cref="IScope"/> instance to control the end of the active period for the <see cref="ISpan"/>. Span will
         /// automatically be finished when <see cref="IDisposable.Dispose"/> is called. It is a programming error to neglect to
         /// call <see cref="IDisposable.Dispose"/> on the returned instance.
         /// </returns>
-        IScope Activate(ISpan span, bool finishSpanOnClose);
+        IScope Activate(ISpan span, bool finishSpanOnDispose);
     }
 }

--- a/src/OpenTracing/ISpanBuilder.cs
+++ b/src/OpenTracing/ISpanBuilder.cs
@@ -86,14 +86,13 @@ namespace OpenTracing
         /// <see cref="ISpanContext"/> when either <see cref="Start"/> or <see cref="StartActive"/> is invoked.
         /// </para>
         /// </summary>
-        /// <param name="finishSpanOnClose">
-        /// Whether span sould automatically be finished when <see cref="IDisposable.Dispose"/> is
-        /// called
+        /// <param name="finishSpanOnDispose">
+        /// Whether span should automatically be finished when <see cref="IDisposable.Dispose"/> is called.
         /// </param>
         /// <returns>An <see cref="IScope"/>, already registered via the <see cref="IScopeManager"/></returns>
         /// <seealso cref="IScopeManager"/>
         /// <seealso cref="IScope"/>
-        IScope StartActive(bool finishSpanOnClose);
+        IScope StartActive(bool finishSpanOnDispose);
 
         /// <summary>
         /// Like <see cref="StartActive"/>, but the returned <see cref="ISpan"/> has not been registered via the


### PR DESCRIPTION
Java has `Closable ` with a `close` method and .NET has `IDisposable` with a `Dispose` method.

To reduce confusion, I think it therefore makes sense to rename the parameter `finishSpanOnClose` to `finishSpanOnDispose`.