### PR TITLE
AsyncLocal based scope manager (ported from Java)

### DIFF
--- a/build-definition.ps1
+++ b/build-definition.ps1
@@ -82,13 +82,12 @@ Task dotnet-test {
     Get-ChildItem .\test -Filter *.csproj -Recurse | ForEach-Object {
 
         $library = Split-Path $_.DirectoryName -Leaf
-        $testResultOutput = Join-Path $testOutput "$library.trx"
 
         Write-Host ""
         Write-Host "Testing $library"
         Write-Host ""
 
-        dotnet test $_.FullName -c $BuildConfiguration --no-build --logger "trx;LogFileName=$testResultOutput"
+        dotnet test $_.FullName -c $BuildConfiguration --no-build
         if ($LASTEXITCODE -ne 0) {
             $testsFailed = $true
         }
@@ -115,6 +114,6 @@ Task dotnet-pack {
         Write-Host "Packaging $library to $libraryOutput"
         Write-Host ""
 
-        exec { dotnet pack $library -c $BuildConfiguration --version-suffix $BuildNumber --no-build --include-source --include-symbols -o $libraryOutput }
+        exec { dotnet pack $library -c $BuildConfiguration --version-suffix $BuildNumber --no-restore --no-build --include-source --include-symbols -o $libraryOutput }
     }
 }

--- a/src/OpenTracing/OpenTracing.csproj
+++ b/src/OpenTracing/OpenTracing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3</TargetFrameworks>
     <Description>This library is a .NET implementation of the OpenTracing API. To fully understand this platform API, it's helpful to be familiar with the OpenTracing project and terminology more generally.
 
 For the time being, mild backwards-incompatible changes may be made without changing the major version number. As OpenTracing and opentracing-csharp mature, backwards compatibility will become more of a priority.</Description>
@@ -9,7 +9,11 @@ For the time being, mild backwards-incompatible changes may be made without chan
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
-    <TargetFrameworks>$(TargetFrameworks);net45</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net452</TargetFrameworks>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+    <Reference Include="System.Runtime.Remoting" />
+  </ItemGroup>
 
 </Project>

--- a/src/OpenTracing/Util/AsyncLocalScope.cs
+++ b/src/OpenTracing/Util/AsyncLocalScope.cs
@@ -1,0 +1,43 @@
+namespace OpenTracing.Util
+{
+    /// <summary>
+    /// The <see cref="AsyncLocalScope"/> is a simple <see cref="IScope"/> implementation
+    /// that relies on C#'s AsyncLocal/CallContext storage primitive.
+    /// </summary>
+    /// <seealso cref="IScopeManager"/>
+    public class AsyncLocalScope : IScope
+    {
+        private readonly AsyncLocalScopeManager _scopeManager;
+        private readonly ISpan _wrappedSpan;
+        private readonly bool _finishOnDispose;
+        private readonly IScope _scopeToRestore;
+
+        public AsyncLocalScope(AsyncLocalScopeManager scopeManager, ISpan wrappedSpan, bool finishOnDispose)
+        {
+            _scopeManager = scopeManager;
+            _wrappedSpan = wrappedSpan;
+            _finishOnDispose = finishOnDispose;
+
+            _scopeToRestore = scopeManager.Active;
+            scopeManager.Active = this;
+        }
+
+        public ISpan Span => _wrappedSpan;
+
+        public void Dispose()
+        {
+            if (_scopeManager.Active != this)
+            {
+                // This shouldn't happen if users call methods in the expected order. Bail out.
+                return;
+            }
+
+            if (_finishOnDispose)
+            {
+                _wrappedSpan.Finish();
+            }
+
+            _scopeManager.Active = _scopeToRestore;
+        }
+    }
+}

--- a/src/OpenTracing/Util/AsyncLocalScopeManager.cs
+++ b/src/OpenTracing/Util/AsyncLocalScopeManager.cs
@@ -1,0 +1,48 @@
+#if NET452
+using System;
+using System.Runtime.Remoting;
+using System.Runtime.Remoting.Messaging;
+#else
+using System.Threading;
+#endif
+
+namespace OpenTracing.Util
+{
+    /// <summary>
+    /// The <see cref="AsyncLocalScopeManager"/> is a simple <see cref="IScopeManager"/> implementation
+    /// that relies on C#'s AsyncLocal/CallContext storage primitive.
+    /// </summary>
+    /// <seealso cref="AsyncLocalScope"/>
+    public class AsyncLocalScopeManager : IScopeManager
+    {
+#if NET452 // AsyncLocal is .NET 4.6+, so fall back to CallContext for .NET 4.5
+        private static readonly string s_logicalDataKey = "__AsyncLocalScope_Current__" + AppDomain.CurrentDomain.Id;
+
+        public IScope Active
+        {
+            get
+            {
+                var handle = CallContext.LogicalGetData(s_logicalDataKey) as ObjectHandle;
+                return handle?.Unwrap() as IScope;
+            }
+            set
+            {
+                CallContext.LogicalSetData(s_logicalDataKey, new ObjectHandle(value));
+            }
+        }
+#else
+        private static AsyncLocal<IScope> s_current = new AsyncLocal<IScope>();
+
+        public IScope Active
+        {
+            get => s_current.Value;
+            set => s_current.Value = value;
+        }
+#endif
+
+        public IScope Activate(ISpan span, bool finishSpanOnDispose)
+        {
+            return new AsyncLocalScope(this, span, finishSpanOnDispose);
+        }
+    }
+}

--- a/test/OpenTracing.Tests/OpenTracing.Tests.csproj
+++ b/test/OpenTracing.Tests/OpenTracing.Tests.csproj
@@ -1,7 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)'=='Windows_NT'">
+    <TargetFrameworks>$(TargetFrameworks);net452</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,9 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTracing.Tests/Util/AsyncLocalScopeManagerTests.cs
+++ b/test/OpenTracing.Tests/Util/AsyncLocalScopeManagerTests.cs
@@ -1,0 +1,80 @@
+﻿using NSubstitute;
+using OpenTracing.Util;
+using Xunit;
+
+namespace OpenTracing.Tests.Util
+{
+    public class AsyncLocalScopeManagerTests
+    {
+        private AsyncLocalScopeManager _source;
+
+
+        public AsyncLocalScopeManagerTests()
+        {
+            _source = new AsyncLocalScopeManager();
+        }
+
+        [Fact]
+        public void MissingActiveScope()
+        {
+            IScope missingScope = _source.Active;
+            Assert.Null(missingScope);
+        }
+
+        [Fact]
+        public void DefaultActivate()
+        {
+            ISpan span = Substitute.For<ISpan>();
+
+            using (IScope scope = _source.Activate(span, false))
+            {
+                Assert.NotNull(scope);
+                IScope otherScope = _source.Active;
+                Assert.Same(otherScope, scope);
+            }
+
+            // Make sure the span is not finished.
+            span.DidNotReceive().Finish();
+
+            // And now it's gone:
+            IScope missingScope = _source.Active;
+            Assert.Null(missingScope);
+        }
+
+        [Fact]
+        public void FinishSpanOnDispose()
+        {
+            ISpan span = Substitute.For<ISpan>();
+
+            using (IScope scope = _source.Activate(span, true))
+            {
+                Assert.NotNull(scope);
+                Assert.NotNull(_source.Active);
+            }
+
+            // Make sure the ISpan got finish()ed.
+            span.Received(1).Finish();
+
+            // Verify it's gone.
+            Assert.Null(_source.Active);
+        }
+
+        [Fact]
+        public void DontFinishSpanNoDispose()
+        {
+            ISpan span = Substitute.For<ISpan>();
+
+            using (IScope scope = _source.Activate(span, false))
+            {
+                Assert.NotNull(scope);
+                Assert.NotNull(_source.Active);
+            }
+
+            // Make sure the ISpan did *not* get finish()ed.
+            span.DidNotReceive().Finish();
+
+            // Verify it's gone.
+            Assert.Null(_source.Active);
+        }
+    }
+}

--- a/test/OpenTracing.Tests/Util/AsyncLocalScopeManagerTests.cs
+++ b/test/OpenTracing.Tests/Util/AsyncLocalScopeManagerTests.cs
@@ -26,7 +26,7 @@ namespace OpenTracing.Tests.Util
         {
             ISpan span = Substitute.For<ISpan>();
 
-            using (IScope scope = _source.Activate(span, false))
+            using (IScope scope = _source.Activate(span, finishSpanOnDispose: false))
             {
                 Assert.NotNull(scope);
                 IScope otherScope = _source.Active;
@@ -46,7 +46,7 @@ namespace OpenTracing.Tests.Util
         {
             ISpan span = Substitute.For<ISpan>();
 
-            using (IScope scope = _source.Activate(span, true))
+            using (IScope scope = _source.Activate(span, finishSpanOnDispose: true))
             {
                 Assert.NotNull(scope);
                 Assert.NotNull(_source.Active);
@@ -64,7 +64,7 @@ namespace OpenTracing.Tests.Util
         {
             ISpan span = Substitute.For<ISpan>();
 
-            using (IScope scope = _source.Activate(span, false))
+            using (IScope scope = _source.Activate(span, finishSpanOnDispose: false))
             {
                 Assert.NotNull(scope);
                 Assert.NotNull(_source.Active);

--- a/test/OpenTracing.Tests/Util/AsyncLocalScopeTests.cs
+++ b/test/OpenTracing.Tests/Util/AsyncLocalScopeTests.cs
@@ -20,12 +20,12 @@ namespace OpenTracing.Tests.Util
             ISpan backgroundSpan = Substitute.For<ISpan>();
             ISpan foregroundSpan = Substitute.For<ISpan>();
 
-            using (IScope backgroundActive = _scopeManager.Activate(backgroundSpan, true))
+            using (IScope backgroundActive = _scopeManager.Activate(backgroundSpan, finishSpanOnDispose: true))
             {
                 Assert.NotNull(backgroundActive);
 
                 // Activate a new Scope on top of the background one.
-                using (IScope foregroundActive = _scopeManager.Activate(foregroundSpan, true))
+                using (IScope foregroundActive = _scopeManager.Activate(foregroundSpan, finishSpanOnDispose: true))
                 {
                     IScope shouldBeForeground = _scopeManager.Active;
                     Assert.Same(foregroundActive, shouldBeForeground);
@@ -51,14 +51,14 @@ namespace OpenTracing.Tests.Util
             ISpan backgroundSpan = Substitute.For<ISpan>();
             ISpan foregroundSpan = Substitute.For<ISpan>();
 
-            using (IScope backgroundActive = _scopeManager.Activate(backgroundSpan, true))
+            using (IScope backgroundActive = _scopeManager.Activate(backgroundSpan, finishSpanOnDispose: true))
             {
                 Assert.NotNull(backgroundActive);
 
                 await Task.Delay(10);
 
                 // Activate a new Scope on top of the background one.
-                using (IScope foregroundActive = _scopeManager.Activate(foregroundSpan, true))
+                using (IScope foregroundActive = _scopeManager.Activate(foregroundSpan, finishSpanOnDispose: true))
                 {
                     await Task.Delay(10);
 
@@ -89,9 +89,9 @@ namespace OpenTracing.Tests.Util
         {
             ISpan span = Substitute.For<ISpan>();
 
-            using (_scopeManager.Activate(span, false))
+            using (_scopeManager.Activate(span, finishSpanOnDispose: false))
             {
-                _scopeManager.Activate(Substitute.For<ISpan>(), false);
+                _scopeManager.Activate(Substitute.For<ISpan>(), finishSpanOnDispose: false);
             }
 
             span.DidNotReceive().Finish();

--- a/test/OpenTracing.Tests/Util/AsyncLocalScopeTests.cs
+++ b/test/OpenTracing.Tests/Util/AsyncLocalScopeTests.cs
@@ -1,0 +1,100 @@
+﻿using System.Threading.Tasks;
+using NSubstitute;
+using OpenTracing.Util;
+using Xunit;
+
+namespace OpenTracing.Tests.Util
+{
+    public class AsyncLocalScopeTests
+    {
+        private readonly AsyncLocalScopeManager _scopeManager;
+
+        public AsyncLocalScopeTests()
+        {
+            _scopeManager = new AsyncLocalScopeManager();
+        }
+
+        [Fact]
+        public void ImplicitSpanStack()
+        {
+            ISpan backgroundSpan = Substitute.For<ISpan>();
+            ISpan foregroundSpan = Substitute.For<ISpan>();
+
+            using (IScope backgroundActive = _scopeManager.Activate(backgroundSpan, true))
+            {
+                Assert.NotNull(backgroundActive);
+
+                // Activate a new Scope on top of the background one.
+                using (IScope foregroundActive = _scopeManager.Activate(foregroundSpan, true))
+                {
+                    IScope shouldBeForeground = _scopeManager.Active;
+                    Assert.Same(foregroundActive, shouldBeForeground);
+                }
+
+                // And now the backgroundActive should be reinstated.
+                IScope shouldBeBackground = _scopeManager.Active;
+                Assert.Same(backgroundActive, shouldBeBackground);
+            }
+
+            // The background and foreground Spans should be finished.
+            backgroundSpan.Received(1).Finish();
+            foregroundSpan.Received(1).Finish();
+
+            // And now nothing is active.
+            IScope missingSpan = _scopeManager.Active;
+            Assert.Null(missingSpan);
+        }
+
+        [Fact]
+        public async Task ImplicitSpanStack_with_Async()
+        {
+            ISpan backgroundSpan = Substitute.For<ISpan>();
+            ISpan foregroundSpan = Substitute.For<ISpan>();
+
+            using (IScope backgroundActive = _scopeManager.Activate(backgroundSpan, true))
+            {
+                Assert.NotNull(backgroundActive);
+
+                await Task.Delay(10);
+
+                // Activate a new Scope on top of the background one.
+                using (IScope foregroundActive = _scopeManager.Activate(foregroundSpan, true))
+                {
+                    await Task.Delay(10);
+
+                    IScope shouldBeForeground = _scopeManager.Active;
+                    Assert.Same(foregroundActive, shouldBeForeground);
+                }
+
+                await Task.Delay(10);
+
+                // And now the backgroundActive should be reinstated.
+                IScope shouldBeBackground = _scopeManager.Active;
+                Assert.Same(backgroundActive, shouldBeBackground);
+            }
+
+            await Task.Delay(10);
+
+            // The background and foreground Spans should be finished.
+            backgroundSpan.Received(1).Finish();
+            foregroundSpan.Received(1).Finish();
+
+            // And now nothing is active.
+            IScope missingSpan = _scopeManager.Active;
+            Assert.Null(missingSpan);
+        }
+
+        [Fact]
+        public void TestDeactivateWhenDifferentSpanIsActive()
+        {
+            ISpan span = Substitute.For<ISpan>();
+
+            using (_scopeManager.Activate(span, false))
+            {
+                _scopeManager.Activate(Substitute.For<ISpan>(), false);
+            }
+
+            span.DidNotReceive().Finish();
+        }
+}
+}


### PR DESCRIPTION
This is a port from opentracing-java's ThreadLocalScopeManager. 

* For storage it either uses `AsyncLocal` (.NET 4.6+, .NET Core) or the `CallContext` (.NET 4.5). This code is based on ASP.NET Core's [HttpContextAccessor](https://github.com/aspnet/HttpAbstractions/blob/622d112372ed11075af160b1fb5a11a7637ff516/src/Microsoft.AspNetCore.Http/HttpContextAccessor.cs).
* Since I had to fiddle around with #if-defs I'm now targeting `netstandard1.3` and `net452` as described in #62 - I'll change the targets here should that issue decide differently.
* The unit tests are also ported from Java.
* I also had to slightly change the build script (as the tests now target multiple frameworks) and I've updated the nuget dependencies.
* I have NOT ported Java's `AutoFinishScopeManager` as I'm not sure if that's required in .NET (due to async/await). I'd say we port that later if someone really needs it.
* The project structure assumes only one OpenTracing package - I'll change this as well should we decide differently in #55.