### PR TITLE
Makes Tag setter public

### DIFF
--- a/src/OpenTracing/Tag/AbstractTag.cs
+++ b/src/OpenTracing/Tag/AbstractTag.cs
@@ -9,6 +9,6 @@
 
         public string Key { get; }
 
-        protected abstract void Set(ISpan span, TTagValue tagValue);
+        public abstract void Set(ISpan span, TTagValue tagValue);
     }
 }

--- a/src/OpenTracing/Tag/BooleanTag.cs
+++ b/src/OpenTracing/Tag/BooleanTag.cs
@@ -7,7 +7,7 @@
         {
         }
 
-        protected override void Set(ISpan span, bool tagValue)
+        public override void Set(ISpan span, bool tagValue)
         {
             span.SetTag(Key, tagValue);
         }

--- a/src/OpenTracing/Tag/IntTag.cs
+++ b/src/OpenTracing/Tag/IntTag.cs
@@ -7,7 +7,7 @@
         {
         }
 
-        protected override void Set(ISpan span, int tagValue)
+        public override void Set(ISpan span, int tagValue)
         {
             span.SetTag(Key, tagValue);
         }

--- a/src/OpenTracing/Tag/StringTag.cs
+++ b/src/OpenTracing/Tag/StringTag.cs
@@ -7,7 +7,7 @@
         {
         }
 
-        protected override void Set(ISpan span, string tagValue)
+        public override void Set(ISpan span, string tagValue)
         {
             span.SetTag(Key, tagValue);
         }


### PR DESCRIPTION
#50 introduced Java's "tag" classes. In Java, the `AbstractTag` has a `protected set()` method and each derived class changes the visibility by having a `public set` method. #50 used `protected` everywhere which obviously doesn't allow one to actually use the classes.

It's not possible in C# to change the visibility of an overriden method so I made `AbstractTag`'s method `public`. I don't see any reason why it shouldn't be public and I don't understand why Java even made this decision.

I'll not mark this as a deviation as it's just a technical difference and not a feature difference.

As this clearly is a bug, I'll merge it tomorrow as well.