### PR TITLE
Add an IFormat marker interface without the type constraint

### DIFF
--- a/src/OpenTracing/Propagation/IFormat.cs
+++ b/src/OpenTracing/Propagation/IFormat.cs
@@ -1,6 +1,14 @@
 ﻿namespace OpenTracing.Propagation
 {
     /// <summary>
+    /// This is a marker interface to allow <see cref="IFormat{TCarrier}"/> instances being used without their type constraint.
+    /// </summary>
+    /// <seealso cref="IFormat{TCarrier}"/>
+    public interface IFormat
+    {
+    }
+
+    /// <summary>
     /// Format instances control the behavior of <see cref="ITracer.Inject{TCarrier}"/> and
     /// <see cref="ITracer.Extract{TCarrier}"/> (and also constrain the type of the carrier parameter to same). Most
     /// OpenTracing users will only reference the <see cref="BuiltinFormats"/> constants. For example:
@@ -12,7 +20,7 @@
     /// </summary>
     /// <seealso cref="ITracer.Inject{TCarrier}"/>
     /// <seealso cref="ITracer.Extract{TCarrier}"/>
-    public interface IFormat<TCarrier>
+    public interface IFormat<TCarrier> : IFormat
     {
     }
 }


### PR DESCRIPTION
In Java it's possible to use a constraint type without the generic constraint by using the `?` placeholder. E.g. one could write `new HashMap<Format<?>()` and store formats with different constraints in that map. However, this is not possible in C#.

As there's currently also no public getter on the interface to access the underlying name (e.g. "TEXT_MAP"), it's impossible for tracers to work with formats in a dynamic way. E.g. it wouldn't be possible to implement [jaegers PropertyRegistry](https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java#L538) that stores a list of formats.

I see two ways to solve this:
* Add a marker interface `IFormat` that does not have the type constraint. It's not used in `Tracer.Inject` and `Tracer.Extract` so it doesn't weaken that contract but it allows tracers to store a list/dictionary of formats. 
* Add a public `Name` property to the `IFormat<TCarrier>` interface and only rely on string comparisons. A tracer would now have a `Dictionary<string, ...>` object.

The existing C# version had a `Name` property but I guess that's a bigger deviation. Having the marker interface only works around a technical difference so this is what this PR would introduce.

Ideally, I'd want to have the marker interface AND the `Name` property (on the marker interface) to give tracers more flexibility. But I guess we should discuss exposing the Name property in opentracing-java.