### PR TITLE
IFormat marker interface and public Format struct (alternative for #67)

### DIFF
--- a/src/OpenTracing/ITracer.cs
+++ b/src/OpenTracing/ITracer.cs
@@ -68,9 +68,9 @@ namespace OpenTracing
         /// <see cref="ITextMap"/> and <see cref="Stream"/>
         /// </param>
         /// <exception cref="UnsupportedFormatException">If the <paramref name="format"/> is not supported by this <see cref="ITracer"/></exception>
-        /// <seealso cref="IFormat{TCarrier}"/>
+        /// <seealso cref="Format{TCarrier}"/>
         /// <seealso cref="BuiltinFormats"/>
-        void Inject<TCarrier>(ISpanContext spanContext, IFormat<TCarrier> format, TCarrier carrier);
+        void Inject<TCarrier>(ISpanContext spanContext, Format<TCarrier> format, TCarrier carrier);
 
         /// <summary>
         /// Extract a SpanContext from a 'carrier' of a given type, presumably after propagation across a process boundary.
@@ -95,8 +95,8 @@ namespace OpenTracing
         /// </param>
         /// <exception cref="UnsupportedFormatException">If the <paramref name="format"/> is not supported by this <see cref="ITracer"/></exception>
         /// <returns>The SpanContext instance holding context to create a Span.</returns>
-        /// <seealso cref="IFormat{TCarrier}"/>
+        /// <seealso cref="Format{TCarrier}"/>
         /// <seealso cref="BuiltinFormats"/>
-        ISpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier);
+        ISpanContext Extract<TCarrier>(Format<TCarrier> format, TCarrier carrier);
     }
 }

--- a/src/OpenTracing/Propagation/BuiltinFormats.cs
+++ b/src/OpenTracing/Propagation/BuiltinFormats.cs
@@ -9,9 +9,9 @@
         /// </summary>
         /// <seealso cref="ITracer.Inject{TCarrier}"/>
         /// <seealso cref="ITracer.Extract{TCarrier}"/>
-        /// <seealso cref="IFormat{TCarrier}"/>
+        /// <seealso cref="Format{TCarrier}"/>
         /// <seealso cref="HttpHeaders"/>
-        public static readonly IFormat<ITextMap> TextMap = new Builtin<ITextMap>("TEXT_MAP");
+        public static readonly Format<ITextMap> TextMap = new Format<ITextMap>("TEXT_MAP");
 
         /// <summary>
         /// The HttpHeaders format allows for HTTP-header-compatible string-string dictionary encodin of SpanContext state
@@ -21,24 +21,8 @@
         /// </summary>
         /// <seealso cref="ITracer.Inject{TCarrier}"/>
         /// <seealso cref="ITracer.Extract{TCarrier}"/>
-        /// <seealso cref="IFormat{TCarrier}"/>
+        /// <seealso cref="Format{TCarrier}"/>
         /// <seealso cref="TextMap"/>
-        public static readonly IFormat<ITextMap> HttpHeaders = new Builtin<ITextMap>("HTTP_HEADERS");
-
-        private struct Builtin<TCarrier> : IFormat<TCarrier>
-        {
-            private readonly string _name;
-
-            public Builtin(string name)
-            {
-                _name = name;
-            }
-
-            /// <summary>Short name for built-in formats as they tend to show up in exception messages</summary>
-            public override string ToString()
-            {
-                return $"{GetType().Name}.{_name}";
-            }
-        }
+        public static readonly Format<ITextMap> HttpHeaders = new Format<ITextMap>("HTTP_HEADERS");
     }
 }

--- a/src/OpenTracing/Propagation/IFormat.cs
+++ b/src/OpenTracing/Propagation/IFormat.cs
@@ -1,5 +1,20 @@
-﻿namespace OpenTracing.Propagation
+﻿using System;
+
+namespace OpenTracing.Propagation
 {
+    /// <summary>
+    /// This is a marker interface to allow <see cref="Format{TCarrier}"/> instances being used without their type constraint.
+    /// </summary>
+    /// <seealso cref="ITracer.Inject{TCarrier}"/>
+    /// <seealso cref="ITracer.Extract{TCarrier}"/>
+    public interface IFormat
+    {
+        /// <summary>
+        /// The unique name for this format.
+        /// </summary>
+        string Name { get; }
+    }
+
     /// <summary>
     /// Format instances control the behavior of <see cref="ITracer.Inject{TCarrier}"/> and
     /// <see cref="ITracer.Extract{TCarrier}"/> (and also constrain the type of the carrier parameter to same). Most
@@ -12,7 +27,20 @@
     /// </summary>
     /// <seealso cref="ITracer.Inject{TCarrier}"/>
     /// <seealso cref="ITracer.Extract{TCarrier}"/>
-    public interface IFormat<TCarrier>
+    public struct Format<TCarrier> : IFormat
     {
+        /// <inheritdoc/>
+        public string Name { get; }
+
+        public Format(string name)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+        }
+
+        /// <summary>Short name for the formats as they tend to show up in exception messages</summary>
+        public override string ToString()
+        {
+            return $"Format.{Name}";
+        }
     }
 }


### PR DESCRIPTION
Relates to #67 (read that first).

This would be my ideal solution. It's a mix of what we've had before (the public `Format` struct) and the `IFormat` marker interface.

Advantages:
* Tracers can use the `IFormat` marker interface to store lists of formats 
* Tracers can use the `Name` property to identify them by name
* The `Format` struct is public which means people who create their own formats don't have to duplicate the existing `BuiltinFormats.Builtin` struct. 
* We can reactive the format unit tests (which are currently pretty much useless due to `BuiltinFormats.Builtin` not being publicly available)

Maybe we should do this as we __have to__ deviate here anyway?!? 

Thoughts?