### PR TITLE
Added SetTag and WithTag for use with OpenTracing.Tag.Tags

### DIFF
--- a/src/OpenTracing/ISpan.cs
+++ b/src/OpenTracing/ISpan.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using OpenTracing.Tag;
 
 namespace OpenTracing
 {
@@ -27,6 +28,9 @@ namespace OpenTracing
 
         /// <summary>Same as <see cref="SetTag(string,string)"/> but for numeric values.</summary>
         ISpan SetTag(string key, double value);
+
+        /// <summary>Set a tag on the Span using the helper in type.</summary>
+        ISpan SetTag<TTagType>(AbstractTag<TTagType> type, TTagType value);
 
         /// <summary>
         /// Log key:value pairs to the Span with the current walltime.

--- a/src/OpenTracing/ISpan.cs
+++ b/src/OpenTracing/ISpan.cs
@@ -29,8 +29,8 @@ namespace OpenTracing
         /// <summary>Same as <see cref="SetTag(string,string)"/> but for numeric values.</summary>
         ISpan SetTag(string key, double value);
 
-        /// <summary>Set a tag on the Span using the helper in type.</summary>
-        ISpan SetTag<TTagType>(AbstractTag<TTagType> type, TTagType value);
+        /// <summary>Set a tag on the Span using the helper in <paramref name="tagSetter"/>.</summary>
+        ISpan SetTag<TTagType>(AbstractTag<TTagType> tagSetter, TTagType value);
 
         /// <summary>
         /// Log key:value pairs to the Span with the current walltime.

--- a/src/OpenTracing/ISpan.cs
+++ b/src/OpenTracing/ISpan.cs
@@ -29,8 +29,17 @@ namespace OpenTracing
         /// <summary>Same as <see cref="SetTag(string,string)"/> but for numeric values.</summary>
         ISpan SetTag(string key, double value);
 
-        /// <summary>Set a tag on the Span using the helper in <paramref name="tagSetter"/>.</summary>
-        ISpan SetTag<TTagType>(AbstractTag<TTagType> tagSetter, TTagType value);
+        /// <summary>Set a tag on the Span using the helper in <paramref name="tag"/>.</summary>
+        ISpan SetTag(BooleanTag tag, bool value);
+
+        /// <summary>Set a tag on the Span using the helper in <paramref name="tag"/>.</summary>
+        ISpan SetTag(IntOrStringTag tag, string value);
+
+        /// <summary>Set a tag on the Span using the helper in <paramref name="tag"/>.</summary>
+        ISpan SetTag(IntTag tag, int value);
+
+        /// <summary>Set a tag on the Span using the helper in <paramref name="tag"/>.</summary>
+        ISpan SetTag(StringTag tag, string value);
 
         /// <summary>
         /// Log key:value pairs to the Span with the current walltime.

--- a/src/OpenTracing/ISpanBuilder.cs
+++ b/src/OpenTracing/ISpanBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using OpenTracing.Tag;
 
 namespace OpenTracing
 {
@@ -57,6 +58,9 @@ namespace OpenTracing
 
         /// <summary>Same as <see cref="ISpan.SetTag(string,double)"/>, but for the span being built.</summary>
         ISpanBuilder WithTag(string key, double value);
+
+        /// <summary>Same as <see cref="ISpan.SetTag{TTagType}(AbstractTag{TTagType},TTagType)"/>, but for the span being built.</summary>
+        ISpanBuilder WithTag<TTagType>(AbstractTag<TTagType> type, TTagType value);
 
         /// <summary>Specify a timestamp of when the <see cref="ISpan"/> was started.</summary>
         ISpanBuilder WithStartTimestamp(DateTimeOffset timestamp);

--- a/src/OpenTracing/ISpanBuilder.cs
+++ b/src/OpenTracing/ISpanBuilder.cs
@@ -59,8 +59,17 @@ namespace OpenTracing
         /// <summary>Same as <see cref="ISpan.SetTag(string,double)"/>, but for the span being built.</summary>
         ISpanBuilder WithTag(string key, double value);
 
-        /// <summary>Same as <see cref="ISpan.SetTag{TTagType}(AbstractTag{TTagType},TTagType)"/>, but for the span being built.</summary>
-        ISpanBuilder WithTag<TTagType>(AbstractTag<TTagType> type, TTagType value);
+        /// <summary>Same as <see cref="ISpan.SetTag(BooleanTag,bool)"/>, but for the span being built.</summary>
+        ISpanBuilder WithTag(BooleanTag tag, bool value);
+
+        /// <summary>Same as <see cref="ISpan.SetTag(IntOrStringTag,string)"/>, but for the span being built.</summary>
+        ISpanBuilder WithTag(IntOrStringTag tag, string value);
+
+        /// <summary>Same as <see cref="ISpan.SetTag(IntTag,int)"/>, but for the span being built.</summary>
+        ISpanBuilder WithTag(IntTag tag, int value);
+
+        /// <summary>Same as <see cref="ISpan.SetTag(StringTag,string)"/>, but for the span being built.</summary>
+        ISpanBuilder WithTag(StringTag tag, string value);
 
         /// <summary>Specify a timestamp of when the <see cref="ISpan"/> was started.</summary>
         ISpanBuilder WithStartTimestamp(DateTimeOffset timestamp);

--- a/src/OpenTracing/Mock/MockSpan.cs
+++ b/src/OpenTracing/Mock/MockSpan.cs
@@ -158,9 +158,9 @@ namespace OpenTracing.Mock
             return SetObjectTag(key, value);
         }
 
-        public ISpan SetTag<TTagType>(AbstractTag<TTagType> type, TTagType value)
+        public ISpan SetTag<TTagType>(AbstractTag<TTagType> tagSetter, TTagType value)
         {
-            type.Set(this, value);
+            tagSetter.Set(this, value);
             return this;
         }
 

--- a/src/OpenTracing/Mock/MockSpan.cs
+++ b/src/OpenTracing/Mock/MockSpan.cs
@@ -160,25 +160,25 @@ namespace OpenTracing.Mock
 
         public ISpan SetTag(BooleanTag tag, bool value)
         {
-            tag.Set(this, value);
+            SetObjectTag(tag.Key, value);
             return this;
         }
 
         public ISpan SetTag(IntOrStringTag tag, string value)
         {
-            tag.Set(this, value);
+            SetObjectTag(tag.Key, value);
             return this;
         }
 
         public ISpan SetTag(IntTag tag, int value)
         {
-            tag.Set(this, value);
+            SetObjectTag(tag.Key, value);
             return this;
         }
 
         public ISpan SetTag(StringTag tag, string value)
         {
-            tag.Set(this, value);
+            SetObjectTag(tag.Key, value);
             return this;
         }
 

--- a/src/OpenTracing/Mock/MockSpan.cs
+++ b/src/OpenTracing/Mock/MockSpan.cs
@@ -158,9 +158,27 @@ namespace OpenTracing.Mock
             return SetObjectTag(key, value);
         }
 
-        public ISpan SetTag<TTagType>(AbstractTag<TTagType> tagSetter, TTagType value)
+        public ISpan SetTag(BooleanTag tag, bool value)
         {
-            tagSetter.Set(this, value);
+            tag.Set(this, value);
+            return this;
+        }
+
+        public ISpan SetTag(IntOrStringTag tag, string value)
+        {
+            tag.Set(this, value);
+            return this;
+        }
+
+        public ISpan SetTag(IntTag tag, int value)
+        {
+            tag.Set(this, value);
+            return this;
+        }
+
+        public ISpan SetTag(StringTag tag, string value)
+        {
+            tag.Set(this, value);
             return this;
         }
 

--- a/src/OpenTracing/Mock/MockSpan.cs
+++ b/src/OpenTracing/Mock/MockSpan.cs
@@ -292,11 +292,6 @@ namespace OpenTracing.Mock
                 Timestamp = timestamp;
                 Fields = new ReadOnlyDictionary<string, object>(fields);
             }
-
-            public override string ToString()
-            {
-                return $"Timestamp: {Timestamp}, Fields: " + string.Join("; ", this.Fields.Select(e => $"{e.Key} = {e.Value}"));
-            }
         }
 
         public sealed class Reference : IEquatable<Reference>

--- a/src/OpenTracing/Mock/MockSpan.cs
+++ b/src/OpenTracing/Mock/MockSpan.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
+using OpenTracing.Tag;
 
 namespace OpenTracing.Mock
 {
@@ -157,6 +158,12 @@ namespace OpenTracing.Mock
             return SetObjectTag(key, value);
         }
 
+        public ISpan SetTag<TTagType>(AbstractTag<TTagType> type, TTagType value)
+        {
+            type.Set(this, value);
+            return this;
+        }
+
         private ISpan SetObjectTag(string key, object value)
         {
             lock (_lock)
@@ -284,6 +291,11 @@ namespace OpenTracing.Mock
             {
                 Timestamp = timestamp;
                 Fields = new ReadOnlyDictionary<string, object>(fields);
+            }
+
+            public override string ToString()
+            {
+                return $"Timestamp: {Timestamp}, Fields: " + string.Join("; ", this.Fields.Select(e => $"{e.Key} = {e.Value}"));
             }
         }
 

--- a/src/OpenTracing/Mock/MockSpanBuilder.cs
+++ b/src/OpenTracing/Mock/MockSpanBuilder.cs
@@ -64,12 +64,6 @@ namespace OpenTracing.Mock
             return this;
         }
 
-        public ISpanBuilder WithTag<TTagType>(AbstractTag<TTagType> type, TTagType value)
-        {
-            _initialTags[type.Key] = value;
-            return this;
-        }
-
         public ISpanBuilder WithTag(string key, int value)
         {
             _initialTags[key] = value;
@@ -79,6 +73,30 @@ namespace OpenTracing.Mock
         public ISpanBuilder WithTag(string key, string value)
         {
             _initialTags[key] = value;
+            return this;
+        }
+
+        public ISpanBuilder WithTag(BooleanTag tag, bool value)
+        {
+            _initialTags[tag.Key] = value;
+            return this;
+        }
+
+        public ISpanBuilder WithTag(IntOrStringTag tag, string value)
+        {
+            _initialTags[tag.Key] = value;
+            return this;
+        }
+
+        public ISpanBuilder WithTag(IntTag tag, int value)
+        {
+            _initialTags[tag.Key] = value;
+            return this;
+        }
+
+        public ISpanBuilder WithTag(StringTag tag, string value)
+        {
+            _initialTags[tag.Key] = value;
             return this;
         }
 

--- a/src/OpenTracing/Mock/MockSpanBuilder.cs
+++ b/src/OpenTracing/Mock/MockSpanBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenTracing.Tag;
 
 namespace OpenTracing.Mock
 {
@@ -60,6 +61,12 @@ namespace OpenTracing.Mock
         public ISpanBuilder WithTag(string key, double value)
         {
             _initialTags[key] = value;
+            return this;
+        }
+
+        public ISpanBuilder WithTag<TTagType>(AbstractTag<TTagType> type, TTagType value)
+        {
+            _initialTags[type.Key] = value;
             return this;
         }
 

--- a/src/OpenTracing/Noop/NoopSpan.cs
+++ b/src/OpenTracing/Noop/NoopSpan.cs
@@ -42,7 +42,22 @@ namespace OpenTracing.Noop
             return this;
         }
 
-        public ISpan SetTag<TTagType>(AbstractTag<TTagType> tagSetter, TTagType value)
+        public ISpan SetTag(BooleanTag tag, bool value)
+        {
+            return this;
+        }
+
+        public ISpan SetTag(IntOrStringTag tag, string value)
+        {
+            return this;
+        }
+
+        public ISpan SetTag(IntTag tag, int value)
+        {
+            return this;
+        }
+
+        public ISpan SetTag(StringTag tag, string value)
         {
             return this;
         }

--- a/src/OpenTracing/Noop/NoopSpan.cs
+++ b/src/OpenTracing/Noop/NoopSpan.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using OpenTracing.Tag;
 
 namespace OpenTracing.Noop
 {
@@ -37,6 +38,11 @@ namespace OpenTracing.Noop
         }
 
         public ISpan SetTag(string key, double value)
+        {
+            return this;
+        }
+
+        public ISpan SetTag<TTagType>(AbstractTag<TTagType> type, TTagType value)
         {
             return this;
         }

--- a/src/OpenTracing/Noop/NoopSpan.cs
+++ b/src/OpenTracing/Noop/NoopSpan.cs
@@ -42,7 +42,7 @@ namespace OpenTracing.Noop
             return this;
         }
 
-        public ISpan SetTag<TTagType>(AbstractTag<TTagType> type, TTagType value)
+        public ISpan SetTag<TTagType>(AbstractTag<TTagType> tagSetter, TTagType value)
         {
             return this;
         }

--- a/src/OpenTracing/Noop/NoopSpanBuilder.cs
+++ b/src/OpenTracing/Noop/NoopSpanBuilder.cs
@@ -51,7 +51,22 @@ namespace OpenTracing.Noop
             return this;
         }
 
-        public ISpanBuilder WithTag<TTagType>(AbstractTag<TTagType> type, TTagType value)
+        public ISpanBuilder WithTag(BooleanTag tag, bool value)
+        {
+            return this;
+        }
+
+        public ISpanBuilder WithTag(IntOrStringTag tag, string value)
+        {
+            return this;
+        }
+
+        public ISpanBuilder WithTag(IntTag tag, int value)
+        {
+            return this;
+        }
+
+        public ISpanBuilder WithTag(StringTag tag, string value)
         {
             return this;
         }

--- a/src/OpenTracing/Noop/NoopSpanBuilder.cs
+++ b/src/OpenTracing/Noop/NoopSpanBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using OpenTracing.Tag;
 
 namespace OpenTracing.Noop
 {
@@ -46,6 +47,11 @@ namespace OpenTracing.Noop
         }
 
         public ISpanBuilder WithTag(string key, double value)
+        {
+            return this;
+        }
+
+        public ISpanBuilder WithTag<TTagType>(AbstractTag<TTagType> type, TTagType value)
         {
             return this;
         }


### PR DESCRIPTION
I found the usage of `OpenTracing.Tag.Tags` somewhat inconvinient, since it was not usable with Fluent API.