### PR TITLE
Improves XML docs (typos, wrong code samples, inconsistent naming, refs)

### DIFF
--- a/src/OpenTracing/IScope.cs
+++ b/src/OpenTracing/IScope.cs
@@ -18,7 +18,7 @@ namespace OpenTracing
     /// </summary>
     public interface IScope : IDisposable
     {
-        /// <summary>The <see cref="ISpan"/> that's been scoped by this <see cref="IScope"/></summary>
+        /// <summary>The <see cref="ISpan"/> that's been scoped by this <see cref="IScope"/>.</summary>
         ISpan Span { get; }
     }
 }

--- a/src/OpenTracing/IScopeManager.cs
+++ b/src/OpenTracing/IScopeManager.cs
@@ -22,14 +22,13 @@ namespace OpenTracing
         IScope Active { get; }
 
         /// <summary>Make a <see cref="ISpan"/> instance active.</summary>
-        /// <param name="span">The <see cref="ISpan"/> that should become the <see cref="Active"/></param>
+        /// <param name="span">The <see cref="ISpan"/> that should become the <see cref="Active"/>.</param>
         /// <param name="finishSpanOnDispose">
         /// Whether span should automatically be finished when <see cref="IDisposable.Dispose"/> is called.
         /// </param>
         /// <returns>
-        /// A <see cref="IScope"/> instance to control the end of the active period for the <see cref="ISpan"/>. Span will
-        /// automatically be finished when <see cref="IDisposable.Dispose"/> is called. It is a programming error to neglect to
-        /// call <see cref="IDisposable.Dispose"/> on the returned instance.
+        /// A <see cref="IScope"/> instance to control the end of the active period for the <see cref="ISpan"/>.
+        /// It is a programming error to neglect to call <see cref="IDisposable.Dispose"/> on the returned instance.
         /// </returns>
         IScope Activate(ISpan span, bool finishSpanOnDispose);
     }

--- a/src/OpenTracing/ISpan.cs
+++ b/src/OpenTracing/ISpan.cs
@@ -4,38 +4,41 @@ using System.Collections.Generic;
 namespace OpenTracing
 {
     /// <summary>
-    /// Represents the OpenTracing specification's Span contract. <seealso cref="IScope"/>
+    /// Represents the OpenTracing specification's span contract. <seealso cref="IScope"/>
     /// <seealso cref="IScopeManager"/> <seealso cref="ISpanBuilder.Start"/> <seealso cref="ISpanBuilder.StartActive"/>
     /// </summary>
     public interface ISpan
     {
         /// <summary>
-        /// Retrieve the associated SpanContext. This may be called at any time, including after calls to
+        /// Retrieve the associated <see cref="ISpanContext"/>. This may be called at any time, including after calls to
         /// <see cref="ISpan.Finish()"/>.
         /// </summary>
-        /// <returns>The SpanContext that encapsulates Span state that sould propagate across process boundaries.</returns>
+        /// <returns>The <see cref="ISpanContext"/> that encapsulates span state that should propagate across process boundaries.</returns>
         ISpanContext Context { get; }
 
-        /// <summary>Set a key:value tag on the Span.</summary>
+        /// <summary>Set a key:value tag on the span.</summary>
+        /// <returns>This span instance, for chaining.</returns>
         ISpan SetTag(string key, string value);
 
         /// <summary>Same as <see cref="SetTag(string,string)"/> but for boolean values.</summary>
+        /// <returns>This span instance, for chaining.</returns>
         ISpan SetTag(string key, bool value);
 
         /// <summary>Same as <see cref="SetTag(string,string)"/> but for numeric values.</summary>
+        /// <returns>This span instance, for chaining.</returns>
         ISpan SetTag(string key, int value);
 
         /// <summary>Same as <see cref="SetTag(string,string)"/> but for numeric values.</summary>
+        /// <returns>This span instance, for chaining.</returns>
         ISpan SetTag(string key, double value);
 
         /// <summary>
-        /// Log key:value pairs to the Span with the current walltime.
+        /// Log key:value pairs to the span with the current timestamp.
         /// <para><em>CAUTIONARY NOTE:</em> not all Tracer implementations support key:value log fields end-to-end. Caveat emptor.</para>
         /// <para>
         /// A contrived example:
         /// <code>
-        /// span.Log(
-        /// new Dictionary{string, object}
+        /// span.Log(new Dictionary&lt;string, object&gt;
         /// {
         ///   { "event", "soft error" },
         ///   { "type", "cache timeout" },
@@ -45,10 +48,10 @@ namespace OpenTracing
         /// </para>
         /// </summary>
         /// <param name="fields">
-        /// key:value log fields. Tracer implementations should support String, numeric, and boolean values;
+        /// key:value log fields. Tracer implementations should support string, int, double, and bool values;
         /// some may also support arbitrary objects.
         /// </param>
-        /// <returns>The Span, for chaining</returns>
+        /// <returns>This span instance, for chaining.</returns>
         /// <seealso cref="Log(string)"/>
         ISpan Log(IDictionary<string, object> fields);
 
@@ -57,56 +60,56 @@ namespace OpenTracing
         /// <para><em>CAUTIONARY NOTE:</em> not all Tracer implementations support key:value log fields end-to-end. Caveat emptor.</para>
         /// </summary>
         /// <param name="timestamp">
-        /// The explicit timestamp for the log record. Must be greater than or equal to the Span's start
+        /// The explicit timestamp for the log record. Must be greater than or equal to the span's start
         /// timestamp.
         /// </param>
         /// <param name="fields">
-        /// key:value log fields. Tracer implementations should support String, numeric, and boolean values;
+        /// key:value log fields. Tracer implementations should support string, int, double, and bool values;
         /// some may also support arbitrary objects.
         /// </param>
-        /// <returns>The Span, for chaining</returns>
+        /// <returns>This span instance, for chaining.</returns>
         /// <seealso cref="Log(DateTimeOffset, string)"/>
         ISpan Log(DateTimeOffset timestamp, IDictionary<string, object> fields);
 
         /// <summary>
-        /// Record an event at the current walltime timestamp. Shorthand for
+        /// Record an event at the current timestamp. Shorthand for
         /// <code>
-        /// span.Log(new Dictionary{string, object}() { { "event", event } });
+        /// span.Log(new Dictionary&lt;string, object&gt; { { "event", event } });
         /// </code>
         /// </summary>
-        /// <param name="event">The event value; often a stable identifier for a moment in the Span lifecycle</param>
-        /// <returns>The Span, for chaining</returns>
+        /// <param name="event">The event value; often a stable identifier for a moment in the span lifecycle.</param>
+        /// <returns>This span instance, for chaining.</returns>
         ISpan Log(string @event);
 
         /// <summary>
         /// Record an event at a specific timestamp. Shorthand for
         /// <code>
-        /// span.Log(timestamp, new Dictionary{string, object}() { { "event", event } });
+        /// span.Log(timestamp, new Dictionary&lt;string, object&gt; { { "event", event } });
         /// </code>
         /// </summary>
         /// <param name="timestamp">
-        /// The explicit timestamp for the log record. Must be greater than or equal to the Span's start
+        /// The explicit timestamp for the log record. Must be greater than or equal to the span's start
         /// timestamp.
         /// </param>
-        /// <param name="event">The event value; often a stable identifier for a moment in the Span lifecycle</param>
-        /// <returns>The Span, for chaining</returns>
+        /// <param name="event">The event value; often a stable identifier for a moment in the span lifecycle.</param>
+        /// <returns>This span instance, for chaining.</returns>
         ISpan Log(DateTimeOffset timestamp, string @event);
 
         /// <summary>
-        /// Sets a baggage item in the Span (and its SpanContext) as a key:value pair. Baggage enables powerful
+        /// Sets a baggage item in the span (and its <see cref="ISpan.Context"/>) as a key:value pair. Baggage enables powerful
         /// distributed context propagation functionality where arbitrary application data can be carried along the full path of
         /// request execution throughout the system. Note 1: Baggage is only propagated to the future (recursive) children of this
-        /// SpanContext. Note 2: Baggage is sent in-band with every subsequent local and remote calls, so this feature must be used
-        /// with care.
+        /// <see cref="ISpan.Context"/>. Note 2: Baggage is sent in-band with every subsequent local and remote calls,
+        /// so this feature must be used with care.
         /// </summary>
-        /// <returns>This Span instance, for chaining</returns>
+        /// <returns>This span instance, for chaining.</returns>
         ISpan SetBaggageItem(string key, string value);
 
         /// <summary>The value of the baggage item identified by <paramref name="key"/>, or null if no such item could be found.</summary>
         string GetBaggageItem(string key);
 
-        /// <summary>Sets the string name for the logical operation this Span represents.</summary>
-        /// <returns>This Span instance, for chaining</returns>
+        /// <summary>Sets the string name for the logical operation this span represents.</summary>
+        /// <returns>This span instance, for chaining.</returns>
         ISpan SetOperationName(string operationName);
 
         /// <summary>
@@ -123,11 +126,11 @@ namespace OpenTracing
         /// <summary>
         /// Sets an explicit end timestamp and records the span.
         /// <para>
-        /// With the exception of calls to Span.context(), this should be the last call made to the span instance, and to do
-        /// otherwise leads to undefined behavior.
+        /// With the exception of calls to <see cref="ISpan.Context"/>, this should be the last call made to the span instance,
+        /// and to do otherwise leads to undefined behavior.
         /// </para>
         /// </summary>
-        /// <param name="finishTimestamp">An explicit finish time</param>
+        /// <param name="finishTimestamp">An explicit finish timestamp.</param>
         /// <seealso cref="ISpan.Context"/>
         void Finish(DateTimeOffset finishTimestamp);
     }

--- a/src/OpenTracing/ISpanBuilder.cs
+++ b/src/OpenTracing/ISpanBuilder.cs
@@ -9,41 +9,40 @@ namespace OpenTracing
         /// </summary>
         ISpanBuilder AsChildOf(ISpanContext parent);
 
-        /// <summary>A shorthand for <see cref="AddReference"/>(References.ChildOf, parent.Context()).
+        /// <summary>A shorthand for <see cref="AddReference"/>(References.ChildOf, parent.Context).
         /// <para>If parent == null, this is a noop.</para>
         /// </summary>
         ISpanBuilder AsChildOf(ISpan parent);
 
         /// <summary>
-        /// Add a reference from the Span being built to a distinct (usually parent) Span. May be called multiples times to
-        /// represent multiple such References.
+        /// Add a reference from the span being built to a distinct (usually parent) span. May be called multiple times to
+        /// represent multiple such references.
         /// <para>
         /// If
         /// <list type="bullet">
-        /// <item>the <see cref="ITracer"/>'s <see cref="IScopeManager.Active"/> is not null, and</item>
-        /// <item>no <b>explicit</b> references are added via <see cref="AddReference"/>, and</item>
-        /// <item><see cref="IgnoreActiveSpan"/> is not invoked,</item>
+        /// <item>the <see cref="ITracer"/>'s <see cref="IScopeManager.Active"/> is not null, and </item>
+        /// <item>no <b>explicit</b> references are added via <see cref="AddReference"/>, and </item>
+        /// <item><see cref="IgnoreActiveSpan"/> is not invoked, </item>
         /// </list>
         /// ... then an inferred <see cref="References.ChildOf"/> reference is created to the <see cref="IScopeManager.Active"/>
         /// <see cref="ISpanContext"/> when either <see cref="StartActive"/> or <see cref="Start"/> is invoked.
         /// </para>
         /// </summary>
         /// <param name="referenceType">
-        /// The reference type, typically one of the constants defined in <see cref="References"/>
+        /// The reference type, typically one of the constants defined in <see cref="References"/>.
         /// </param>
         /// <param name="referencedContext">
-        /// The SpanContext being referenced; e.g., for a <see cref="References.ChildOf"/>
-        /// reference, the referenecedContext is the parent. If referencedContext==null, the call to <see cref="AddReference"/> is
+        /// The <see cref="ISpanContext"/> being referenced; e.g., for a <see cref="References.ChildOf"/>
+        /// reference, the referenecedContext is the parent. If referencedContext == null, the call to <see cref="AddReference"/> is
         /// a noop.
         /// </param>
         /// <seealso cref="References"/>
         ISpanBuilder AddReference(string referenceType, ISpanContext referencedContext);
 
         /// <summary>
-        /// Do not create an implicit <see cref="References.ChildOf"/> reference to othe
+        /// Do not create an implicit <see cref="References.ChildOf"/> reference to the
         /// <see cref="IScopeManager.Active"/>.
         /// </summary>
-        /// <returns></returns>
         ISpanBuilder IgnoreActiveSpan();
 
         /// <summary>Same as <see cref="ISpan.SetTag(string,string)"/>, but for the span being built.</summary>
@@ -66,21 +65,20 @@ namespace OpenTracing
         /// <para>
         /// The returned <see cref="IScope"/> supports using(). For example:
         /// <code>
-        /// using (IScope scope = tracer.BuildSpan("...").StartActive(false))
+        /// using (IScope scope = tracer.BuildSpan("...").StartActive(finishSpanOnDispose: true))
         /// {
         ///     // (Do work)
         ///     scope.Span.SetTag( ... );  // etc, etc
         /// }
-        /// // Span does not finish automatically when the Scope is closed as
-        /// // 'finishOnClose' is false
+        /// // Span finishes automatically only when 'finishSpanOnDispose' is true
         /// </code>
         /// </para>
         /// <para>
         /// If
         /// <list type="bullet">
-        /// <item>the <see cref="ITracer"/>'s <see cref="IScopeManager.Active"/> is not null, and</item>
-        /// <item>no <b>explicit</b> references are added via <see cref="AddReference"/>, and</item>
-        /// <item><see cref="IgnoreActiveSpan"/> is not invoked,</item>
+        /// <item>the <see cref="ITracer"/>'s <see cref="IScopeManager.Active"/> is not null, and </item>
+        /// <item>no <b>explicit</b> references are added via <see cref="AddReference"/>, and </item>
+        /// <item><see cref="IgnoreActiveSpan"/> is not invoked, </item>
         /// </list>
         /// ... then an inferred <see cref="References.ChildOf"/> reference is created to the <see cref="IScopeManager.Active"/>
         /// <see cref="ISpanContext"/> when either <see cref="Start"/> or <see cref="StartActive"/> is invoked.
@@ -89,7 +87,7 @@ namespace OpenTracing
         /// <param name="finishSpanOnDispose">
         /// Whether span should automatically be finished when <see cref="IDisposable.Dispose"/> is called.
         /// </param>
-        /// <returns>An <see cref="IScope"/>, already registered via the <see cref="IScopeManager"/></returns>
+        /// <returns>An <see cref="IScope"/>, already registered via the <see cref="IScopeManager"/>.</returns>
         /// <seealso cref="IScopeManager"/>
         /// <seealso cref="IScope"/>
         IScope StartActive(bool finishSpanOnDispose);
@@ -99,8 +97,8 @@ namespace OpenTracing
         /// <see cref="IScopeManager"/>.
         /// </summary>
         /// <returns>
-        /// The newly-started Span instance, which as *not* been automatically registered via the
-        /// <see cref="IScopeManager"/>
+        /// The newly-started span instance, which has *not* been automatically registered via the
+        /// <see cref="IScopeManager"/>.
         /// </returns>
         /// <seealso cref="StartActive(bool)"/>
         ISpan Start();

--- a/src/OpenTracing/ISpanContext.cs
+++ b/src/OpenTracing/ISpanContext.cs
@@ -3,16 +3,16 @@
 namespace OpenTracing
 {
     /// <summary>
-    /// SpanContext represents Span state that must propagate to descendant Spans and across process boundaries.
-    /// SpanContext is logically divided into two pieces: (1) the user-level "Baggage" that propagates across Span boundaries
-    /// and (2) any Tracer-implementation-specific fields that are needed to identify or otherwise contextualize the associated
-    /// Span instance(e.g., a { trace_id, span_id, sampled } tuple).
+    /// <see cref="ISpanContext"/> represents span state that must propagate to descendant spans and across process boundaries.
+    /// <see cref="ISpanContext"/> is logically divided into two pieces: (1) the user-level "Baggage" that propagates across span
+    /// boundaries and (2) any Tracer-implementation-specific fields that are needed to identify or otherwise contextualize the associated
+    /// span instance(e.g., a { trace_id, span_id, sampled } tuple).
     /// </summary>
     /// <seealso cref="ISpan.SetBaggageItem"/>
     /// <seealso cref="ISpan.GetBaggageItem"/>
     public interface ISpanContext
     {
-        /// <returns>All zero or more baggage items propagating along with the associated Span</returns>
+        /// <returns>All zero or more baggage items propagating along with the associated span.</returns>
         /// <seealso cref="ISpan.SetBaggageItem"/>
         /// <seealso cref="ISpan.GetBaggageItem"/>
         IEnumerable<KeyValuePair<string, string>> GetBaggageItems();

--- a/src/OpenTracing/ITracer.cs
+++ b/src/OpenTracing/ITracer.cs
@@ -4,91 +4,94 @@ using OpenTracing.Propagation;
 
 namespace OpenTracing
 {
-    /// <summary>Tracer is a simple, thin interface for Span creation and propagation across arbitrary transports.</summary>
+    /// <summary>
+    /// <see cref="ITracer"/> is a simple, thin interface for span creation and propagation across arbitrary transports.
+    /// </summary>
     public interface ITracer
     {
         /// <summary>The current <see cref="IScopeManager"/>, which may be a noop but may not be null.</summary>
         IScopeManager ScopeManager { get; }
 
         /// <summary>
-        /// Get the active <see cref="ISpan"/>. This is a shorthand for <code>ITracer.ScopeManager.Active.Span</code>,
+        /// Get the active <see cref="ISpan"/>. This is a shorthand for <code>tracer.ScopeManager.Active.Span</code>,
         /// and null will be returned if <see cref="IScopeManager.Active"/> is null.
         /// </summary>
         ISpan ActiveSpan { get; }
 
         /// <summary>
-        /// Return a new SpanBuilder for a Span with the given 'operationName'.
+        /// Returns a new <see cref="ISpanBuilder"/> for a span with the given 'operationName'.
         /// <para>You can override the operationName later via <see cref="ISpan.SetOperationName"/>.</para>
         /// <para>
         /// A contrived example:
         /// <code>
         /// ITracer tracer = ...
         ///
-        /// // Note if there is a ITracer.ActiveSpan(), it will be used as the target of an implicit CHILD_OF
-        /// // Refernece for "workSpan" when StartActive() is invoked.
-        /// using (IActiveSpan workSpan = tracer.BuildSpan("DoWork").StartActive())
+        /// // Note if there is a tracer.ActiveSpan, it will be used as the target of an implicit CHILD_OF
+        /// // reference for "workScope.Span" when StartActive() is invoked.
+        /// using (IScope workScope = tracer.BuildSpan("DoWork").StartActive(finishSpanOnDispose: true))
         /// {
-        ///     workSpan.SetTag("...", "...");
+        ///     workScope.Span.SetTag("...", "...");
         ///     // etc, etc
         /// }
         ///
-        /// // It's also possible to create Spans manually, bypassing the ActiveSpanSource activation.
-        /// Span http = tracer.BuildSpan("HandleHTTPRequest")
+        /// // It's also possible to create spans manually, bypassing the IScopeManager activation.
+        /// ISpan http = tracer.BuildSpan("HandleHTTPRequest")
         ///                   .AsChildOf(rpcSpanContext)  // an explicit parent
         ///                   .WithTag("user_agent", req.UserAgent)
         ///                   .WithTag("lucky_number", 42)
-        ///                   .StartManual();
+        ///                   .Start();
         ///         </code>
         /// </para>
         /// </summary>
-        /// <param name="operationName"></param>
+        /// <param name="operationName">Sets the string name for the logical operation the span being built represents.</param>
         ISpanBuilder BuildSpan(string operationName);
 
         /// <summary>
-        /// Inect a SpanContext into a 'carrier' of a given type, presumably for propagation across process boundaries.
+        /// Inect a <see cref="ISpanContext"/> into a 'carrier' of a given type, presumably for propagation across process boundaries.
         /// <para>
         /// Example:
         /// <code>
-        /// Tracer tracer = ...
-        /// Span clientSpan = ...
+        /// ITracer tracer = ...
+        /// ISpan clientSpan = ...
         /// ITextMap httpHeadersCarrier = new AnHttpHeaderCarrier(httpRequest);
-        /// tracer.Inject(span.Context(), BuiltinFormats.HttpHeaders, httpHeadersCarrier);
+        /// tracer.Inject(span.Context, BuiltinFormats.HttpHeaders, httpHeadersCarrier);
         /// </code>
         /// </para>
         /// </summary>
-        /// <typeparam name="TCarrier">The carrier type, which also parametrizes the Format.</typeparam>
-        /// <param name="spanContext">The SpanContext instance to inject into the carrier</param>
-        /// <param name="format">The Fromat of the carrier</param>
+        /// <typeparam name="TCarrier">The <paramref name="carrier"/> type, which also parametrizes the <paramref name="format"/>.</typeparam>
+        /// <param name="spanContext">The <see cref="ISpanContext"/> instance to inject into the <paramref name="carrier"/>.</param>
+        /// <param name="format">The <see cref="IFormat{TCarrier}"/> of the <paramref name="carrier"/>.</param>
         /// <param name="carrier">
-        /// The carrier for the SpanContext state. All Tracer.Inject implementations must support
-        /// <see cref="ITextMap"/> and <see cref="Stream"/>
+        /// The carrier for the <see cref="ISpanContext"/> state. All <see cref="Inject"/> implementations must support
+        /// <see cref="ITextMap"/> and <see cref="Stream"/>.
         /// </param>
         /// <seealso cref="IFormat{TCarrier}"/>
         /// <seealso cref="BuiltinFormats"/>
         void Inject<TCarrier>(ISpanContext spanContext, IFormat<TCarrier> format, TCarrier carrier);
 
         /// <summary>
-        /// Extract a SpanContext from a 'carrier' of a given type, presumably after propagation across a process boundary.
+        /// Extract a <see cref="ISpanContext"/> from a <paramref name="carrier"/> of a given type,
+        /// presumably after propagation across a process boundary.
         /// <para>
         /// Example:
         /// <code>
-        /// Tracer tracer = ...
+        /// ITracer tracer = ...
         /// ITextMap httpHeadersCarrier = new AnHttpHeaderCarrier(httpRequest);
-        /// SpanContext spanCtx = tracer.Extract(BuiltinFormats.HttpHeaders, httpHeadersCarrier);
-        /// ... = tracer.BuildSpan("...").AsChildOf(spanCtx).StartActive();
+        /// ISpanContext spanContext = tracer.Extract(BuiltinFormats.HttpHeaders, httpHeadersCarrier);
+        /// ... = tracer.BuildSpan("...").AsChildOf(spanContext).StartActive(true);
         /// </code>
         /// </para>
         /// If the span serialized state is invalid (corrupt, wrong version, etc) inside the carrier this will result in an
         /// <see cref="ArgumentException"/>.
         /// </summary>
-        /// <exception cref="ArgumentException">If the span serialized state is invalid (corrupt, wrong version, etc)</exception>
-        /// <typeparam name="TCarrier">The carrier type, which also parametrizes the Format.</typeparam>
-        /// <param name="format">The Format of the carrier</param>
+        /// <exception cref="ArgumentException">If the span serialized state is invalid (corrupt, wrong version, etc).</exception>
+        /// <typeparam name="TCarrier">The <paramref name="carrier"/> type, which also parametrizes the <paramref name="format"/>.</typeparam>
+        /// <param name="format">The <see cref="IFormat{TCarrier}"/> of the <paramref name="carrier"/>.</param>
         /// <param name="carrier">
-        /// The carrier for the SpanContext state. All Tracer.Extract() implementations must support
+        /// The carrier for the <see cref="ISpanContext"/> state. All <see cref="Extract"/> implementations must support
         /// <see cref="ITextMap"/> and <see cref="Stream"/>.
         /// </param>
-        /// <returns>The SpanContext instance holding context to create a Span.</returns>
+        /// <returns>The <see cref="ISpanContext"/> instance holding context to create a span.</returns>
         /// <seealso cref="IFormat{TCarrier}"/>
         /// <seealso cref="BuiltinFormats"/>
         ISpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier);

--- a/src/OpenTracing/LogFields.cs
+++ b/src/OpenTracing/LogFields.cs
@@ -7,25 +7,24 @@
     /// </summary>
     public static class LogFields
     {
-        /// <summary>The type or "kind" of an error (only for event="error" logs). E.g., "Exception", "OSError"</summary>
+        /// <summary>The type or "kind" of an error (only for event="error" logs). E.g., "Exception", "OSError".</summary>
         public const string ErrorKind = "error.kind";
 
         /// <summary>
         /// The actual <see cref="System.Exception"/> object instance.
-        /// instance
         /// </summary>
         public const string ErrorObject = "error.object";
 
         /// <summary>
-        /// A stable identifier for some notable moment in the lifetime of a Span. For instance, a mutex lock acquisition
+        /// A stable identifier for some notable moment in the lifetime of a span. For instance, a mutex lock acquisition
         /// or release or the sorts of lifetime events in a browser page load described in the Performance.timing specification.
-        /// E.g., from Zipkin, "cs", "sr", "ss", or "cr". Or, more generally, "initialized" or "timed out". For errors, "error"
+        /// E.g., from Zipkin, "cs", "sr", "ss", or "cr". Or, more generally, "initialized" or "timed out". For errors, "error".
         /// </summary>
         public const string Event = "event";
 
         /// <summary>
         /// A concise, human-readable, one-line message explaining the event. E.g., "Could not connect to backend", "Cache
-        /// invalidation succeeded"
+        /// invalidation succeeded".
         /// </summary>
         public const string Message = "message";
 

--- a/src/OpenTracing/Mock/MockSpan.cs
+++ b/src/OpenTracing/Mock/MockSpan.cs
@@ -8,7 +8,7 @@ namespace OpenTracing.Mock
 {
     /// <summary>
     /// MockSpans are created via <see cref="MockTracer.BuildSpan"/>, but they are also returned via calls to
-    /// <see cref="MockTracer.FinishedSpans"/>. They provide accessors to all Span state.
+    /// <see cref="MockTracer.FinishedSpans"/>. They provide accessors to all span state.
     /// </summary>
     /// <seealso cref="MockTracer.FinishedSpans"/>
     public sealed class MockSpan : ISpan
@@ -38,7 +38,7 @@ namespace OpenTracing.Mock
         private readonly List<Exception> _errors = new List<Exception>();
 
         /// <summary>
-        /// The spanId of the Span's first <see cref="References.ChildOf"/> reference, or the first reference of any type,
+        /// The spanId of the span's first <see cref="References.ChildOf"/> reference, or the first reference of any type,
         /// or 0 if no reference exists.
         /// </summary>
         /// <seealso cref="MockSpanContext.SpanId"/>
@@ -48,7 +48,7 @@ namespace OpenTracing.Mock
         public DateTimeOffset StartTimestamp { get; }
 
         /// <summary>
-        /// The finish time of the Span; only valid after a call to <see cref="Finish()"/>.
+        /// The finish time of the span; only valid after a call to <see cref="Finish()"/>.
         /// </summary>
         public DateTimeOffset FinishTimestamp
         {

--- a/src/OpenTracing/Mock/MockSpanContext.cs
+++ b/src/OpenTracing/Mock/MockSpanContext.cs
@@ -21,8 +21,8 @@ namespace OpenTracing.Mock
         /// An internal constructor to create a new <see cref="MockSpanContext"/>.
         /// This should only be called by <see cref="MockSpan"/> and/or <see cref="MockTracer"/>.
         /// </summary>
-        /// <param name="traceId">The id of the trace</param>
-        /// <param name="spanId">The id of the span</param>
+        /// <param name="traceId">The id of the trace.</param>
+        /// <param name="spanId">The id of the span.</param>
         /// <param name="baggage">The MockContext takes ownership of the baggage parameter.</param>
         /// <seealso cref="MockSpanContext.WithBaggageItem(string, string)"/>
         internal MockSpanContext(long traceId, long spanId, IDictionary<string, string> baggage)

--- a/src/OpenTracing/Mock/MockTracer.cs
+++ b/src/OpenTracing/Mock/MockTracer.cs
@@ -9,8 +9,8 @@ namespace OpenTracing.Mock
     /// <summary>
     /// <see cref="MockTracer"/> makes it easy to test the semantics of OpenTracing instrumentation.
     /// <para/>
-    /// By using a <see cref="MockTracer"/> as an <see cref="ITracer"/> implementation for unittests, a developer can assert that Span
-    /// properties and relationships with other Spans are defined as expected by instrumentation code.
+    /// By using a <see cref="MockTracer"/> as an <see cref="ITracer"/> implementation for unittests, a developer can assert that span
+    /// properties and relationships with other spans are defined as expected by instrumentation code.
     /// <para/>
     /// The MockTracerTests class has simple usage examples.
     /// </summary>
@@ -54,7 +54,7 @@ namespace OpenTracing.Mock
         /// <summary>
         /// Clear the <see cref="FinishedSpans"/> queue.
         /// <para/>
-        /// Note that this does *not* have any effect on Spans created by MockTracer that have not Finish()ed yet; those
+        /// Note that this does *not* have any effect on spans created by MockTracer that have not Finish()ed yet; those
         /// will still be enqueued in <see cref="FinishedSpans"/> when they Finish().
         /// </summary>
         public void Reset()

--- a/src/OpenTracing/Propagation/BuiltinFormats.cs
+++ b/src/OpenTracing/Propagation/BuiltinFormats.cs
@@ -3,9 +3,9 @@
     public static class BuiltinFormats
     {
         /// <summary>
-        /// The ITextMap format allows for arbitrary string-string dictionary encoding of SpanContext state for
+        /// The 'TextMap' format allows for arbitrary string-string dictionary encoding of <see cref="ISpanContext"/> state for
         /// <see cref="ITracer.Inject{TCarrier}"/> and <see cref="ITracer.Extract{TCarrier}"/>. Unlike <see cref="HttpHeaders"/>,
-        /// the builtin ITextMap format expresses no constraints on keys or values.
+        /// the builtin 'TextMap' format expresses no constraints on keys or values.
         /// </summary>
         /// <seealso cref="ITracer.Inject{TCarrier}"/>
         /// <seealso cref="ITracer.Extract{TCarrier}"/>
@@ -14,9 +14,9 @@
         public static readonly IFormat<ITextMap> TextMap = new Builtin<ITextMap>("TEXT_MAP");
 
         /// <summary>
-        /// The HttpHeaders format allows for HTTP-header-compatible string-string dictionary encodin of SpanContext state
+        /// The 'HttpHeaders' format allows for HTTP-header-compatible string-string dictionary encoding of <see cref="ISpanContext"/> state
         /// for <see cref="ITracer.Inject{TCarrier}"/> and <see cref="ITracer.Extract{TCarrier}"/>. I.e, keys written to the
-        /// ITextMap MUST be suitable for HTTP header keys (which are poorly defined but certainly restricted); and similarly for
+        /// <see cref="ITextMap"/> MUST be suitable for HTTP header keys (which are poorly defined but certainly restricted); and similarly for
         /// values (i.e., URL-escaped and "not too long").
         /// </summary>
         /// <seealso cref="ITracer.Inject{TCarrier}"/>
@@ -34,7 +34,7 @@
                 _name = name;
             }
 
-            /// <summary>Short name for built-in formats as they tend to show up in exception messages</summary>
+            /// <summary>Short name for built-in formats as they tend to show up in exception messages.</summary>
             public override string ToString()
             {
                 return $"{GetType().Name}.{_name}";

--- a/src/OpenTracing/Propagation/IFormat.cs
+++ b/src/OpenTracing/Propagation/IFormat.cs
@@ -1,13 +1,13 @@
 ﻿namespace OpenTracing.Propagation
 {
     /// <summary>
-    /// Format instances control the behavior of <see cref="ITracer.Inject{TCarrier}"/> and
+    /// <see cref="IFormat{TCarrier}"/> instances control the behavior of <see cref="ITracer.Inject{TCarrier}"/> and
     /// <see cref="ITracer.Extract{TCarrier}"/> (and also constrain the type of the carrier parameter to same). Most
     /// OpenTracing users will only reference the <see cref="BuiltinFormats"/> constants. For example:
     /// <code>
-    /// Tracer tracer = ...
-    /// IFormat{ITextMap} httpCarrier = new AnHttpHeaderCarrier(httpRequest);
-    /// ISpanContext spanCtx = tracer.Extract(BuiltinFormats.HttpHeaders, httpHeaderRequest);
+    /// ITracer tracer = ...
+    /// ITextMap httpCarrier = new AnHttpHeaderCarrier(httpRequest);
+    /// ISpanContext spanContext = tracer.Extract(BuiltinFormats.HttpHeaders, httpHeaderRequest);
     /// </code>
     /// </summary>
     /// <seealso cref="ITracer.Inject{TCarrier}"/>

--- a/src/OpenTracing/Propagation/ITextMap.cs
+++ b/src/OpenTracing/Propagation/ITextMap.cs
@@ -4,16 +4,20 @@ namespace OpenTracing.Propagation
 {
     /// <summary>
     /// <see cref="ITextMap"/> is a built-in carrier for <see cref="ITracer.Inject{TCarrier}"/> and
-    /// <see cref="ITracer.Extract{TCarrier}"/>. ITextMap implementations allows Tracers to read and write key:value String
+    /// <see cref="ITracer.Extract{TCarrier}"/>. ITextMap implementations allows Tracers to read and write key:value string
     /// pairs from arbitrary underlying sources of data.
     /// </summary>
     /// <seealso cref="ITracer.Inject{TCarrier}"/>
     /// <seealso cref="ITracer.Extract{TCarrier}"/>
     public interface ITextMap : IEnumerable<KeyValuePair<string, string>>
     {
-        /// <summary>Puts a key:value pair into the TextMapWriter's backing store.</summary>
-        /// <param name="key">A string, possibly with constraints dictated by the particular Format this ITextMap is paired with</param>
-        /// <param name="value">A string, possibly with constraints dictated by the particular Format this ITextMap is paired with</param>
+        /// <summary>Puts a key:value pair into the ITextMap's backing store.</summary>
+        /// <param name="key">
+        /// A string, possibly with constraints dictated by the particular <see cref="IFormat{TCarrier}"/> this ITextMap is paired with.
+        /// </param>
+        /// <param name="value">
+        /// A string, possibly with constraints dictated by the particular <see cref="IFormat{TCarrier}"/> this ITextMap is paired with.
+        /// </param>
         /// <seealso cref="ITracer.Inject{TCarrier}"/>
         /// <seealso cref="BuiltinFormats.TextMap"/>
         /// <seealso cref="BuiltinFormats.HttpHeaders"/>

--- a/src/OpenTracing/Propagation/TextMapExtractAdapter.cs
+++ b/src/OpenTracing/Propagation/TextMapExtractAdapter.cs
@@ -5,8 +5,9 @@ using System.Collections.Generic;
 namespace OpenTracing.Propagation
 {
     /// <summary>
-    /// A ITextMap carrier for use with Tracer.extract() ONLY (it has no mutating methods). Note that the ITextMap
-    /// interface can be made to wrap around arbitrary data types (not just Dictionary{string, string} as illustrated here).
+    /// A <see cref="ITextMap"/> carrier for use with <see cref="ITracer.Extract"/> ONLY (it has no mutating methods). Note that the
+    /// <see cref="ITextMap"/> interface can be made to wrap around arbitrary data types
+    /// (not just <code>Dictionary&lt;string, string&gt;</code> as illustrated here).
     /// </summary>
     /// <seealso cref="ITracer.Extract{TCarrier}"/>
     public sealed class TextMapExtractAdapter : ITextMap

--- a/src/OpenTracing/Propagation/TextMapInjectAdapter.cs
+++ b/src/OpenTracing/Propagation/TextMapInjectAdapter.cs
@@ -5,9 +5,9 @@ using System.Collections.Generic;
 namespace OpenTracing.Propagation
 {
     /// <summary>
-    /// A TextMap carrier for use with <see cref="ITracer.Inject{TCarrier}"/> ONLY (it has no read methods). Note that
-    /// the ITextMap interface can be made to wrap around arbitrary data types (not just Dictionary{string, string} as
-    /// illustrated here).
+    /// A <see cref="ITextMap"/> carrier for use with <see cref="ITracer.Inject{TCarrier}"/> ONLY (it has no read methods). Note that
+    /// the <see cref="ITextMap"/> interface can be made to wrap around arbitrary data types
+    /// (not just <code>Dictionary&lt;string, string&gt;</code> as illustrated here).
     /// </summary>
     /// <seealso cref="ITracer.Inject{TCarrier}"/>
     public sealed class TextMapInjectAdapter : ITextMap

--- a/src/OpenTracing/References.cs
+++ b/src/OpenTracing/References.cs
@@ -2,20 +2,20 @@
 {
     /// <summary>
     /// <see cref="References"/> is essentially a namespace for the official OpenTracing reference types. References
-    /// are used by <see cref="ITracer.BuildSpan"/> to describe the relationships between Spans.
+    /// are used by <see cref="ITracer.BuildSpan"/> to describe the relationships between spans.
     /// </summary>
     /// <seealso cref="ISpanBuilder.AddReference"/>
     public static class References
     {
         /// <summary>
         /// See https://github.com/opentracing/specification/blob/master/specification.md#references-between-spans for
-        /// more information about CHILD_OF references
+        /// more information about CHILD_OF references.
         /// </summary>
         public const string ChildOf = "child_of";
 
         /// <summary>
         /// See https://github.com/opentracing/specification/blob/master/specification.md#references-between-spans for
-        /// more information about FOLLOWS_FROM references
+        /// more information about FOLLOWS_FROM references.
         /// </summary>
         public const string FollowsFrom = "follows_from";
     }

--- a/src/OpenTracing/Tag/Tags.cs
+++ b/src/OpenTracing/Tag/Tags.cs
@@ -50,7 +50,7 @@
         /// <summary>PeerPort records the port number of the peer.</summary>
         public static readonly IntTag PeerPort = new IntTag("peer.port");
 
-        /// <summary>SamplingPriority determines the priority of sampling this Span.</summary>
+        /// <summary>SamplingPriority determines the priority of sampling this span.</summary>
         public static readonly IntTag SamplingPriority = new IntTag("sampling.priority");
 
         /// <summary>SpanKind hints at the relationship between spans, e.g. client/server.</summary>
@@ -59,12 +59,12 @@
         /// <summary>Component is a low-cardinality identifier of the module, library, or package that is instrumented.</summary>
         public static readonly StringTag Component = new StringTag("component");
 
-        /// <summary>Error indicates whether a Span ended in an error state.</summary>
+        /// <summary>Error indicates whether a span ended in an error state.</summary>
         public static readonly BooleanTag Error = new BooleanTag("error");
 
         /// <summary>
         /// DbType indicates the type of Database. For any SQL database, "sql". For others, the lower-case database
-        /// category, e.g. "cassandra", "hbase", or "redis"
+        /// category, e.g. "cassandra", "hbase", or "redis".
         /// </summary>
         public static readonly StringTag DbType = new StringTag("db.type");
 
@@ -74,7 +74,7 @@
         /// </summary>
         public static readonly StringTag DbInstance = new StringTag("db.instance");
 
-        /// <summary>DbUser indicates the user name of Database, e.g. "readonly_user" or "reporting_user"</summary>
+        /// <summary>DbUser indicates the user name of Database, e.g. "readonly_user" or "reporting_user".</summary>
         public static readonly StringTag DbUser = new StringTag("db.user");
 
         /// <summary>

--- a/test/OpenTracing.Tests/Mock/MockTracerTests.cs
+++ b/test/OpenTracing.Tests/Mock/MockTracerTests.cs
@@ -21,7 +21,7 @@ namespace OpenTracing.Tests.Mock
         [Fact]
         public void TestRootSpan()
         {
-            // Create and finish a root Span.
+            // Create and finish a root span.
             var tracer = new MockTracer();
 
             var span = tracer.BuildSpan("tester")
@@ -38,7 +38,7 @@ namespace OpenTracing.Tests.Mock
 
             List<MockSpan> finishedSpans = tracer.FinishedSpans();
 
-            // Check that the Span looks right.
+            // Check that the span looks right.
 
             Assert.Single(finishedSpans);
             MockSpan finishedSpan = finishedSpans[0];
@@ -77,7 +77,7 @@ namespace OpenTracing.Tests.Mock
         [Fact]
         public void TestChildSpan()
         {
-            // Create and finish a root Span.
+            // Create and finish a root span.
             MockTracer tracer = new MockTracer();
             ISpan originalParent = tracer.BuildSpan("parent").WithStartTimestamp(GetTestTimestamp(100)).Start();
             ISpan originalChild = tracer.BuildSpan("child").WithStartTimestamp(GetTestTimestamp(200)).AsChildOf(originalParent).Start();
@@ -86,7 +86,7 @@ namespace OpenTracing.Tests.Mock
 
             List<MockSpan> finishedSpans = tracer.FinishedSpans();
 
-            // Check that the Spans look right.
+            // Check that the spans look right.
             Assert.Equal(2, finishedSpans.Count);
             MockSpan child = finishedSpans[0];
             MockSpan parent = finishedSpans[1];

--- a/test/OpenTracing.Tests/Util/AsyncLocalScopeTests.cs
+++ b/test/OpenTracing.Tests/Util/AsyncLocalScopeTests.cs
@@ -36,7 +36,7 @@ namespace OpenTracing.Tests.Util
                 Assert.Same(backgroundActive, shouldBeBackground);
             }
 
-            // The background and foreground Spans should be finished.
+            // The background and foreground spans should be finished.
             backgroundSpan.Received(1).Finish();
             foregroundSpan.Received(1).Finish();
 
@@ -75,7 +75,7 @@ namespace OpenTracing.Tests.Util
 
             await Task.Delay(10);
 
-            // The background and foreground Spans should be finished.
+            // The background and foreground spans should be finished.
             backgroundSpan.Received(1).Finish();
             foregroundSpan.Received(1).Finish();
 


### PR DESCRIPTION
This PR only touches XML docs. It fixes typos, wrong code samples, inconsistent naming (e.g. Span vs span), missing punctuation and adds xml references where possible.

I'll merge this on Tuesday if there's no objections.