### PR TITLE
StartActive() overload with finishSpanOnDispose:true

### DIFF
--- a/src/OpenTracing/IScopeManager.cs
+++ b/src/OpenTracing/IScopeManager.cs
@@ -14,7 +14,7 @@ namespace OpenTracing
         /// <see cref="IScope.Span"/>.
         /// <para>
         /// If there is an non-null <see cref="IScope"/>, its wrapped <see cref="ISpan"/> becomes an implicit parent of any
-        /// newly-created <see cref="ISpan"/> at <see cref="ISpanBuilder.StartActive"/> time (rather than at
+        /// newly-created <see cref="ISpan"/> at <see cref="ISpanBuilder.StartActive(bool)"/> time (rather than at
         /// <see cref="ITracer.BuildSpan"/> time).
         /// </para>
         /// </summary>

--- a/src/OpenTracing/ISpan.cs
+++ b/src/OpenTracing/ISpan.cs
@@ -5,7 +5,7 @@ namespace OpenTracing
 {
     /// <summary>
     /// Represents the OpenTracing specification's span contract. <seealso cref="IScope"/>
-    /// <seealso cref="IScopeManager"/> <seealso cref="ISpanBuilder.Start"/> <seealso cref="ISpanBuilder.StartActive"/>
+    /// <seealso cref="IScopeManager"/> <seealso cref="ISpanBuilder.Start"/> <seealso cref="ISpanBuilder.StartActive(bool)"/>
     /// </summary>
     public interface ISpan
     {

--- a/src/OpenTracing/ISpanBuilder.cs
+++ b/src/OpenTracing/ISpanBuilder.cs
@@ -25,7 +25,7 @@ namespace OpenTracing
         /// <item><see cref="IgnoreActiveSpan"/> is not invoked, </item>
         /// </list>
         /// ... then an inferred <see cref="References.ChildOf"/> reference is created to the <see cref="IScopeManager.Active"/>
-        /// <see cref="ISpanContext"/> when either <see cref="StartActive"/> or <see cref="Start"/> is invoked.
+        /// <see cref="ISpanContext"/> when either <see cref="StartActive(bool)"/> or <see cref="Start"/> is invoked.
         /// </para>
         /// </summary>
         /// <param name="referenceType">
@@ -61,6 +61,36 @@ namespace OpenTracing
         ISpanBuilder WithStartTimestamp(DateTimeOffset timestamp);
 
         /// <summary>
+        /// Same as <see cref="StartActive(bool)"/> with <c>finishSpanOnDispose: true</c>.
+        /// <para/>
+        /// Returns a newly started and activated <see cref="IScope"/>. The underlying span is finished
+        /// automatically when the scope is disposed.
+        /// <para/>
+        /// The returned <see cref="IScope"/> supports using(). For example:
+        /// <code>
+        /// using (IScope scope = tracer.BuildSpan("...").StartActive())
+        /// {
+        ///     // (Do work)
+        ///     scope.Span.SetTag( ... );  // etc, etc
+        /// } // Span finishes automatically on Dispose.
+        /// </code>
+        /// <para>
+        /// If
+        /// <list type="bullet">
+        /// <item>the <see cref="ITracer"/>'s <see cref="IScopeManager.Active"/> is not null, and </item>
+        /// <item>no <b>explicit</b> references are added via <see cref="AddReference"/>, and </item>
+        /// <item><see cref="IgnoreActiveSpan"/> is not invoked, </item>
+        /// </list>
+        /// ... then an inferred <see cref="References.ChildOf"/> reference is created to the <see cref="IScopeManager.Active"/>
+        /// <see cref="ISpanContext"/> when either <see cref="Start"/> or <see cref="StartActive()"/> is invoked.
+        /// </para>
+        /// </summary>
+        /// <returns>An <see cref="IScope"/>, already registered via the <see cref="IScopeManager"/>.</returns>
+        /// <seealso cref="IScopeManager"/>
+        /// <seealso cref="IScope"/>
+        IScope StartActive();
+
+        /// <summary>
         /// Returns a newly started and activated <see cref="IScope"/>.
         /// <para>
         /// The returned <see cref="IScope"/> supports using(). For example:
@@ -81,7 +111,7 @@ namespace OpenTracing
         /// <item><see cref="IgnoreActiveSpan"/> is not invoked, </item>
         /// </list>
         /// ... then an inferred <see cref="References.ChildOf"/> reference is created to the <see cref="IScopeManager.Active"/>
-        /// <see cref="ISpanContext"/> when either <see cref="Start"/> or <see cref="StartActive"/> is invoked.
+        /// <see cref="ISpanContext"/> when either <see cref="Start"/> or <see cref="StartActive(bool)"/> is invoked.
         /// </para>
         /// </summary>
         /// <param name="finishSpanOnDispose">
@@ -93,7 +123,7 @@ namespace OpenTracing
         IScope StartActive(bool finishSpanOnDispose);
 
         /// <summary>
-        /// Like <see cref="StartActive"/>, but the returned <see cref="ISpan"/> has not been registered via the
+        /// Like <see cref="StartActive(bool)"/>, but the returned <see cref="ISpan"/> has not been registered via the
         /// <see cref="IScopeManager"/>.
         /// </summary>
         /// <returns>

--- a/src/OpenTracing/Mock/MockSpanBuilder.cs
+++ b/src/OpenTracing/Mock/MockSpanBuilder.cs
@@ -81,6 +81,11 @@ namespace OpenTracing.Mock
             return this;
         }
 
+        public IScope StartActive()
+        {
+            return StartActive(finishSpanOnDispose: true);
+        }
+
         public IScope StartActive(bool finishSpanOnDispose)
         {
             ISpan span = Start();

--- a/src/OpenTracing/Noop/NoopSpanBuilder.cs
+++ b/src/OpenTracing/Noop/NoopSpanBuilder.cs
@@ -55,6 +55,11 @@ namespace OpenTracing.Noop
             return this;
         }
 
+        public IScope StartActive()
+        {
+            return NoopScopeManager.NoopScope.Instance;
+        }
+
         public IScope StartActive(bool finishSpanOnDispose)
         {
             return NoopScopeManager.NoopScope.Instance;


### PR DESCRIPTION
Resolves #73.

This is done by adding the method to the interface. I *think* this is better as it keeps everything in one place. We have to rely on tracers implementing this correctly but this shouldn't be a concern IMO (as they also have to implement all other behaviors correctly).

An alternative would be to add the method as an extension method. The advantage would be that it is non-breaking and that we could provide the implementation. However this would make the API a little bit more complex as methods would then be on interfaces and extension types. Also, NoopTracer could no longer immediately return (which probably is a negligible cost though).

Thoughts?