### PR TITLE
Make NoopTracer types public

### DIFF
--- a/src/OpenTracing/Noop/NoopScopeManager.cs
+++ b/src/OpenTracing/Noop/NoopScopeManager.cs
@@ -3,7 +3,7 @@ namespace OpenTracing.Noop
     /// <summary>
     /// A noop (i.e., cheap-as-possible) implementation of an <see cref="IScopeManager"/>.
     /// </summary>
-    internal sealed class NoopScopeManager : IScopeManager
+    public sealed class NoopScopeManager : IScopeManager
     {
         internal static readonly NoopScopeManager Instance = new NoopScopeManager();
 
@@ -23,7 +23,7 @@ namespace OpenTracing.Noop
             return nameof(NoopScopeManager);
         }
 
-        internal sealed class NoopScope : IScope
+        public sealed class NoopScope : IScope
         {
             internal static readonly NoopScope Instance = new NoopScope();
 

--- a/src/OpenTracing/Noop/NoopSpan.cs
+++ b/src/OpenTracing/Noop/NoopSpan.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace OpenTracing.Noop
 {
-    internal sealed class NoopSpan : ISpan
+    public sealed class NoopSpan : ISpan
     {
         internal static readonly NoopSpan Instance = new NoopSpan();
 

--- a/src/OpenTracing/Noop/NoopSpanBuilder.cs
+++ b/src/OpenTracing/Noop/NoopSpanBuilder.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace OpenTracing.Noop
 {
-    internal sealed class NoopSpanBuilder : ISpanBuilder
+    public sealed class NoopSpanBuilder : ISpanBuilder
     {
         internal static NoopSpanBuilder Instance = new NoopSpanBuilder();
 

--- a/src/OpenTracing/Noop/NoopSpanContext.cs
+++ b/src/OpenTracing/Noop/NoopSpanContext.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace OpenTracing.Noop
 {
-    internal sealed class NoopSpanContext : ISpanContext
+    public sealed class NoopSpanContext : ISpanContext
     {
         internal static readonly NoopSpanContext Instance = new NoopSpanContext();
 

--- a/src/OpenTracing/Noop/NoopTracer.cs
+++ b/src/OpenTracing/Noop/NoopTracer.cs
@@ -2,7 +2,7 @@ using OpenTracing.Propagation;
 
 namespace OpenTracing.Noop
 {
-    internal sealed class NoopTracer : ITracer
+    public sealed class NoopTracer : ITracer
     {
         internal static readonly NoopTracer Instance = new NoopTracer();
 


### PR DESCRIPTION
I want to be able to check if a given `ITracer` instance is a `NoopTracer`. My scenario is my [csharp-netcore](https://github.com/opentracing-contrib/csharp-netcore/issues/8) instrumentation library where I don't even want to start the instrumentation components if no tracer is registered. 

It's currently possible to do this via `if (tracer == NoopTracerFactory.Create()) { }` but that looks a bit weird IMO.

In opentracing-java the `Noop*` types are already public via interfaces - see e.g. [`NoopSpan`](https://github.com/opentracing/opentracing-java/blob/master/opentracing-noop/src/main/java/io/opentracing/noop/NoopSpan.java#L21). We haven't migrated these interface as it's not possible in C# to add the static `INSTANCE` variables to these interfaces.

So by making our types `public`, we would fix another deviation.

Note that the constructors are still private and the static `Instance` variables are still `internal` so the only way to get a `NoopTracer` still is a call to `NoopTracerFactory.Create`.