### PR TITLE
Updating MockTracer to use AsyncLocalScopeManager

### DIFF
--- a/src/OpenTracing/Mock/MockTracer.cs
+++ b/src/OpenTracing/Mock/MockTracer.cs
@@ -47,7 +47,7 @@ namespace OpenTracing.Mock
         /// to <see cref="ITracer.Inject"/> and/or <see cref="ITracer.Extract"/>.
         /// </summary>
         public MockTracer(IPropagator propagator)
-            : this(NoopScopeManager.Instance, propagator)
+            : this(new AsyncLocalScopeManager(), propagator)
         {
         }
 


### PR DESCRIPTION
Brings https://github.com/opentracing/opentracing-java/pull/264 to this repo.

As this has already been merged in Java, I'll immediately merge it here as well.