### PR TITLE
Always return NoopScope / NoopSpan for ScopeManager.Active / Tracer.ActiveSpan

### DIFF
--- a/src/OpenTracing/Noop/NoopScopeManager.cs
+++ b/src/OpenTracing/Noop/NoopScopeManager.cs
@@ -7,7 +7,7 @@ namespace OpenTracing.Noop
     {
         internal static readonly NoopScopeManager Instance = new NoopScopeManager();
 
-        public IScope Active => null;
+        public IScope Active => NoopScope.Instance;
 
         private NoopScopeManager()
         {

--- a/src/OpenTracing/Noop/NoopTracer.cs
+++ b/src/OpenTracing/Noop/NoopTracer.cs
@@ -8,7 +8,7 @@ namespace OpenTracing.Noop
 
         public IScopeManager ScopeManager => NoopScopeManager.Instance;
 
-        public ISpan ActiveSpan => null;
+        public ISpan ActiveSpan => NoopSpan.Instance;
 
         private NoopTracer()
         {

--- a/test/OpenTracing.Tests/Noop/NoopScopeManagerTests.cs
+++ b/test/OpenTracing.Tests/Noop/NoopScopeManagerTests.cs
@@ -1,0 +1,17 @@
+using OpenTracing.Noop;
+using Xunit;
+
+namespace OpenTracing.Tests.Noop
+{
+    public class NoopScopeManagerTests
+    {
+
+        [Fact]
+        public void ActiveValueToleratesUse()
+        {
+            IScope active = NoopScopeManager.Instance.Active;
+            Assert.NotNull(active);
+            active.Dispose();
+        }
+    }
+}

--- a/test/OpenTracing.Tests/Noop/NoopTests.cs
+++ b/test/OpenTracing.Tests/Noop/NoopTests.cs
@@ -21,15 +21,16 @@ namespace OpenTracing.Tests.Noop
         {
             var tracer = NoopTracerFactory.Create();
 
-            Assert.IsType<NoopScopeManager>(tracer.ScopeManager);
+            Assert.Same(NoopScopeManager.Instance, tracer.ScopeManager);
         }
 
         [Fact]
-        public void Tracer_initially_has_no_active_span()
+        public void Tracer_ActiveSpan_is_NoopSpan()
         {
             var tracer = NoopTracerFactory.Create();
 
-            Assert.Null(tracer.ActiveSpan);
+            var span = tracer.ActiveSpan;
+            Assert.Same(NoopSpan.Instance, span);
         }
 
         [Fact]
@@ -39,7 +40,7 @@ namespace OpenTracing.Tests.Noop
 
             var spanBuilder = tracer.BuildSpan("noop");
 
-            Assert.IsType<NoopSpanBuilder>(spanBuilder);
+            Assert.Same(NoopSpanBuilder.Instance, spanBuilder);
         }
 
         [Fact]
@@ -61,7 +62,7 @@ namespace OpenTracing.Tests.Noop
             var scope = tracer.BuildSpan("noop")
                 .StartActive(finishSpanOnDispose: false);
 
-            Assert.IsType<NoopScopeManager.NoopScope>(scope);
+            Assert.Same(NoopScopeManager.NoopScope.Instance, scope);
         }
 
         [Fact]
@@ -72,29 +73,29 @@ namespace OpenTracing.Tests.Noop
             var scope = tracer.BuildSpan("noop")
                 .StartActive(finishSpanOnDispose: false);
 
-            Assert.IsType<NoopSpan>(scope.Span);
+            Assert.Same(NoopSpan.Instance, scope.Span);
         }
 
         [Fact]
-        public void StartActive_does_NOT_set_Tracer_ActiveSpan()
+        public void StartActive_sets_Tracer_ActiveSpan()
         {
             var tracer = NoopTracerFactory.Create();
 
             var scope = tracer.BuildSpan("noop")
                 .StartActive(finishSpanOnDispose: false);
 
-            Assert.Null(tracer.ActiveSpan);
+            Assert.Same(NoopSpan.Instance, tracer.ActiveSpan);
         }
 
         [Fact]
-        public void StartActive_does_NOT_set_ScopeManager_Active()
+        public void StartActive_sets_ScopeManager_Active()
         {
             var tracer = NoopTracerFactory.Create();
 
             var scope = tracer.BuildSpan("noop")
                 .StartActive(finishSpanOnDispose: false);
 
-            Assert.Null(tracer.ScopeManager.Active);
+            Assert.Same(NoopScopeManager.NoopScope.Instance, tracer.ScopeManager.Active);
         }
 
         [Fact]
@@ -104,7 +105,7 @@ namespace OpenTracing.Tests.Noop
 
             var span = tracer.BuildSpan("noop").Start();
 
-            Assert.IsType<NoopSpan>(span);
+            Assert.Same(NoopSpan.Instance, span);
         }
 
         [Fact]
@@ -119,23 +120,23 @@ namespace OpenTracing.Tests.Noop
         }
 
         [Fact]
-        public void Start_does_NOT_set_Tracer_ActiveSpan()
+        public void Start_sets_Tracer_ActiveSpan()
         {
             var tracer = NoopTracerFactory.Create();
 
             var span = tracer.BuildSpan("noop").Start();
 
-            Assert.Null(tracer.ActiveSpan);
+            Assert.Same(NoopSpan.Instance, tracer.ActiveSpan);
         }
 
         [Fact]
-        public void Start_does_NOT_set_ScopeManager_Active()
+        public void Start_sets_ScopeManager_Active()
         {
             var tracer = NoopTracerFactory.Create();
 
             var span = tracer.BuildSpan("noop").Start();
 
-            Assert.Null(tracer.ScopeManager.Active);
+            Assert.Same(NoopScopeManager.NoopScope.Instance, tracer.ScopeManager.Active);
         }
 
         [Fact]
@@ -147,11 +148,11 @@ namespace OpenTracing.Tests.Noop
 
             var scope = tracer.ScopeManager.Activate(span, finishSpanOnDispose: false);
 
-            Assert.IsType<NoopScopeManager.NoopScope>(scope);
+            Assert.Same(NoopScopeManager.NoopScope.Instance, scope);
         }
 
         [Fact]
-        public void ScopeManager_does_NOT_set_Active_on_Activate()
+        public void ScopeManager_sets_Active_on_Activate()
         {
             var tracer = NoopTracerFactory.Create();
 
@@ -159,8 +160,8 @@ namespace OpenTracing.Tests.Noop
 
             tracer.ScopeManager.Activate(span, finishSpanOnDispose: false);
 
-            Assert.Null(tracer.ScopeManager.Active);
-            Assert.Null(tracer.ActiveSpan);
+            Assert.Same(NoopScopeManager.NoopScope.Instance, tracer.ScopeManager.Active);
+            Assert.Same(NoopSpan.Instance, tracer.ActiveSpan);
         }
 
         [Fact]
@@ -170,7 +171,7 @@ namespace OpenTracing.Tests.Noop
 
             var span = tracer.BuildSpan("noop").Start();
 
-            Assert.IsType<NoopSpanContext>(span.Context);
+            Assert.Same(NoopSpanContext.Instance, span.Context);
         }
 
         [Fact]
@@ -182,7 +183,7 @@ namespace OpenTracing.Tests.Noop
 
             var spanContext = tracer.Extract(BuiltinFormats.TextMap, new TextMapExtractAdapter(carrier));
 
-            Assert.IsType<NoopSpanContext>(spanContext);
+            Assert.Same(NoopSpanContext.Instance, spanContext);
         }
 
         [Fact]

--- a/test/OpenTracing.Tests/Noop/NoopTracerTests.cs
+++ b/test/OpenTracing.Tests/Noop/NoopTracerTests.cs
@@ -1,0 +1,18 @@
+using OpenTracing.Noop;
+using OpenTracing.Tag;
+using Xunit;
+
+namespace OpenTracing.Tests.Noop
+{
+    public class NoopTracerTest
+    {
+
+        [Fact]
+        public void ActiveSpanValueToleratesUse()
+        {
+            ISpan activeSpan = NoopTracer.Instance.ActiveSpan;
+            Assert.NotNull(activeSpan);
+            Tags.Error.Set(activeSpan, true);
+        }
+    }
+}


### PR DESCRIPTION
This brings https://github.com/opentracing/opentracing-java/pull/263 to this repository.

Description from there:
> In special circumstances, code may automatically generate spans, negating the need to always check if Tracer.activeSpan() is null. Under these circumstances, the Noop Tracer and ScopeManager will cause NPEs when they return null values when their active methods are accessed via the GlobalTracer. This
prevents code from running successfully when using Noop Tracers.
>
> This minor change allows users to depend that their code will genuinely Noop under all use cases.

We have a separate `NoopTests` class in our repo so I had to adjust these tests. I also changed everything to `AssertSame(Noop*.Instance, ...)` instead of `Assert.IsType<Noop*>(...)` as this is a better check for our use case IMO.

As I changed these tests as well, I'll keep this PR open for a few days.