### PR TITLE
[WIP] added ThreadLocalScopeManager

### DIFF
--- a/src/OpenTracing/Util/ThreadLocalScope.cs
+++ b/src/OpenTracing/Util/ThreadLocalScope.cs
@@ -1,0 +1,42 @@
+﻿namespace OpenTracing.Util
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// A <see cref="T:OpenTracing.IScope" /> primitive that relies on thread local storage for
+    /// managing active scopes. Intended to be used in systems where multiple logical,
+    /// related operations are all executed in the same thread albeit at different times.
+    /// </summary>
+    public class ThreadLocalScope : IScope
+    {
+        private readonly ThreadLocalScopeManager _scopeManager;
+        private readonly bool _finishOnDispose;
+        private readonly IScope _scopeToRestore;
+
+        public ThreadLocalScope(ThreadLocalScopeManager scopeManager, ISpan wrappedSpan, bool finishOnDispose)
+        {
+            _scopeManager = scopeManager;
+            Span = wrappedSpan;
+            _finishOnDispose = finishOnDispose;
+            _scopeToRestore = scopeManager.Active;
+            scopeManager.Active = this;
+        }
+
+        public void Dispose()
+        {
+            if (_scopeManager.Active != this)
+            {
+                // This shouldn't happen if users call methods in the expected order. Bail out.
+                return;
+            }
+
+            if (_finishOnDispose)
+            {
+                Span.Finish();
+            }
+
+            _scopeManager.Active = _scopeToRestore;
+        }
+
+        public ISpan Span { get; }
+    }
+}

--- a/src/OpenTracing/Util/ThreadLocalScopeManager.cs
+++ b/src/OpenTracing/Util/ThreadLocalScopeManager.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace OpenTracing.Util
+{
+    /// <summary>
+    /// An <see cref="IScopeManager"/> implementation that relies on thread local storage for
+    /// managing active scopes. Intended to be used in systems where multiple logical,
+    /// related operations are all executed in the same thread albeit at different times.
+    /// </summary>
+    public class ThreadLocalScopeManager : IScopeManager
+    {
+        /*
+         * Went with ThreadStatic over ThreadLocal<T> because we don't
+         * want scopes to be initialized upon thread initialization by default
+         * and we want ThreadStatic's mutability for restoring / replacing scopes.
+         */
+        [ThreadStatic]
+        private static IScope _active;
+
+        public IScope Active
+        {
+            get => _active;
+            set => _active = value;
+        }
+        public IScope Activate(ISpan span, bool finishSpanOnDispose)
+        {
+            return new ThreadLocalScope(this, span, finishSpanOnDispose);
+        }
+    }
+}


### PR DESCRIPTION
Need to add some specs for this still, but since I was already working on this in another project I thought I'd contribute it back.

When I'm using OpenTracing in combination with [Akka.NET](http://getakka.net/) or [DotNetty](https://github.com/azure/dotnetty), it's been really helpful to me to have a `ThreadStatic` means of looking up active scopes since the operations inside one actor message process or the processing of one parsed message on the socket occur within the same thread but the handlers for those operations might be implemented in different, disconnected stages potentially. Propagating active scope data down to all of the handlers via `ThreadStatic` storage has been very helpful, rather than trying to do it through something I implemented at the application layer.