### PR TITLE
Use IEnumerable<KeyValuePair<string, object>> for Log() methods (again)

### DIFF
--- a/src/OpenTracing/ISpan.cs
+++ b/src/OpenTracing/ISpan.cs
@@ -66,10 +66,10 @@ namespace OpenTracing
         /// </param>
         /// <returns>This span instance, for chaining.</returns>
         /// <seealso cref="Log(string)"/>
-        ISpan Log(IDictionary<string, object> fields);
+        ISpan Log(IEnumerable<KeyValuePair<string, object>> fields);
 
         /// <summary>
-        /// Like <see cref="Log(IDictionary{string, object})"/>, but with an explicit timestamp.
+        /// Like <see cref="Log(IEnumerable{KeyValuePair{string, object}})"/>, but with an explicit timestamp.
         /// <para><em>CAUTIONARY NOTE:</em> not all Tracer implementations support key:value log fields end-to-end. Caveat emptor.</para>
         /// </summary>
         /// <param name="timestamp">
@@ -82,7 +82,7 @@ namespace OpenTracing
         /// </param>
         /// <returns>This span instance, for chaining.</returns>
         /// <seealso cref="Log(DateTimeOffset, string)"/>
-        ISpan Log(DateTimeOffset timestamp, IDictionary<string, object> fields);
+        ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields);
 
         /// <summary>
         /// Record an event at the current timestamp. Shorthand for

--- a/src/OpenTracing/Mock/MockSpan.cs
+++ b/src/OpenTracing/Mock/MockSpan.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -193,12 +192,12 @@ namespace OpenTracing.Mock
             }
         }
 
-        public ISpan Log(IDictionary<string, object> fields)
+        public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
         {
             return Log(DateTimeOffset.UtcNow, fields);
         }
 
-        public ISpan Log(DateTimeOffset timestamp, IDictionary<string, object> fields)
+        public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
         {
             lock (_lock)
             {
@@ -306,10 +305,16 @@ namespace OpenTracing.Mock
 
             public IReadOnlyDictionary<string, object> Fields { get; }
 
-            public LogEntry(DateTimeOffset timestamp, IDictionary<string, object> fields)
+            public LogEntry(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
             {
                 Timestamp = timestamp;
-                Fields = new ReadOnlyDictionary<string, object>(fields);
+
+                var fieldsDictionary = new Dictionary<string, object>();
+                foreach (var kvp in fields)
+                {
+                    fieldsDictionary[kvp.Key] = kvp.Value;
+                }
+                Fields = fieldsDictionary;
             }
         }
 

--- a/src/OpenTracing/Noop/NoopSpan.cs
+++ b/src/OpenTracing/Noop/NoopSpan.cs
@@ -62,12 +62,12 @@ namespace OpenTracing.Noop
             return this;
         }
 
-        public ISpan Log(IDictionary<string, object> fields)
+        public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
         {
             return this;
         }
 
-        public ISpan Log(DateTimeOffset timestamp, IDictionary<string, object> fields)
+        public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
         {
             return this;
         }


### PR DESCRIPTION
In v0.10.0 we used `Log(IEnumerable<KeyValuePair<string, object>> fields)`. With our big java parity-change in v0.11.0 we changed the signature to `Log(IDictionary<string, object> fields)`. This was an attempt to translate Java's `Map<K, V>` interface.

Java's `Map` interface does not implement any other interfaces. But in C# `IDictionary<K,V>` implements `ICollection<KeyValuePair<K, V>>` and `ICollection<T>` implements `IEnumerable<T>` so moving back to `IEnumerable<KeyValuePair<string, object>>` would be the most general type and a reasonable deviation from Java.

Using `IDictionary` does not give any guarantees regarding uniqueness anyway as people could call `Log()` with the same key multiple times or they could also use a non-unique implementation of `IDictionary`. This means that tracers have to deal with duplicate keys anyway and define their own behavior (e.g. last wins)

This change would also make it easier to use more efficient data structures (e.g. linked lists).

This is a breaking change for tracers, but it will NOT break instrumentation code as it will just use a more general interface.