### PR TITLE
Implement "Trace Identifiers" RFC

### DIFF
--- a/examples/OpenTracing.Examples/ActiveSpanReplacement/ActiveSpanReplacementTest.cs
+++ b/examples/OpenTracing.Examples/ActiveSpanReplacement/ActiveSpanReplacementTest.cs
@@ -33,7 +33,7 @@ namespace OpenTracing.Examples.ActiveSpanReplacement
 
             // initial task is not related in any way to those two tasks
             Assert.NotEqual(spans[0].Context.TraceId, spans[1].Context.TraceId);
-            Assert.Equal(0, spans[0].ParentId);
+            Assert.Null(spans[0].ParentId);
 
             Assert.Null(_tracer.ScopeManager.Active);
         }

--- a/examples/OpenTracing.Examples/CommonRequestHandler/HandlerTest.cs
+++ b/examples/OpenTracing.Examples/CommonRequestHandler/HandlerTest.cs
@@ -38,8 +38,8 @@ namespace OpenTracing.Examples.CommonRequestHandler
             Assert.Equal(Tags.SpanKindClient, finished[1].Tags[Tags.SpanKind.Key]);
 
             Assert.NotEqual(finished[0].Context.TraceId, finished[1].Context.TraceId);
-            Assert.Equal(0, finished[0].ParentId);
-            Assert.Equal(0, finished[1].ParentId);
+            Assert.Null(finished[0].ParentId);
+            Assert.Null(finished[1].ParentId);
 
             Assert.Null(_tracer.ScopeManager.Active);
         }
@@ -96,7 +96,7 @@ namespace OpenTracing.Examples.CommonRequestHandler
             Assert.Equal(parent.Context.SpanId, finished[1].ParentId);
 
             // third span should not have parent.
-            Assert.Equal(0, finished[2].ParentId);
+            Assert.Null(finished[2].ParentId);
         }
 
         private static MockSpan GetOneByOperationName(List<MockSpan> spans, string name)

--- a/src/OpenTracing/ISpanContext.cs
+++ b/src/OpenTracing/ISpanContext.cs
@@ -12,6 +12,16 @@ namespace OpenTracing
     /// <seealso cref="ISpan.GetBaggageItem"/>
     public interface ISpanContext
     {
+        /// <summary>
+        /// Globally unique. Every span in a trace shares this ID.
+        /// </summary>
+        string TraceId { get; }
+
+        /// <summary>
+        /// Unique within a trace. Each span within a trace contains a different ID.
+        /// </summary>
+        string SpanId { get; }
+
         /// <returns>All zero or more baggage items propagating along with the associated span.</returns>
         /// <seealso cref="ISpan.SetBaggageItem"/>
         /// <seealso cref="ISpan.GetBaggageItem"/>

--- a/src/OpenTracing/Mock/MockSpan.cs
+++ b/src/OpenTracing/Mock/MockSpan.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 
@@ -21,9 +22,9 @@ namespace OpenTracing.Mock
         /// <summary>
         /// A simple-as-possible (consecutive for repeatability) id generator.
         /// </summary>
-        private static long NextId()
+        private static string NextId()
         {
-            return Interlocked.Increment(ref _nextIdCounter);
+            return Interlocked.Increment(ref _nextIdCounter).ToString(CultureInfo.InvariantCulture);
         }
 
         private readonly object _lock = new object();
@@ -39,11 +40,11 @@ namespace OpenTracing.Mock
 
         /// <summary>
         /// The spanId of the span's first <see cref="References.ChildOf"/> reference, or the first reference of any type,
-        /// or 0 if no reference exists.
+        /// or null if no reference exists.
         /// </summary>
         /// <seealso cref="MockSpanContext.SpanId"/>
         /// <seealso cref="MockSpan.References"/>
-        public long ParentId { get; }
+        public string ParentId { get; }
 
         public DateTimeOffset StartTimestamp { get; }
 
@@ -120,7 +121,7 @@ namespace OpenTracing.Mock
             {
                 // we are a root span
                 _context = new MockSpanContext(NextId(), NextId(), new Dictionary<string, string>());
-                ParentId = 0;
+                ParentId = null;
             }
             else
             {

--- a/src/OpenTracing/Mock/MockSpanContext.cs
+++ b/src/OpenTracing/Mock/MockSpanContext.cs
@@ -13,9 +13,9 @@ namespace OpenTracing.Mock
     {
         private readonly IDictionary<string, string> _baggage;
 
-        public long TraceId { get; }
+        public string TraceId { get; }
 
-        public long SpanId { get; }
+        public string SpanId { get; }
 
         /// <summary>
         /// An internal constructor to create a new <see cref="MockSpanContext"/>.
@@ -25,7 +25,7 @@ namespace OpenTracing.Mock
         /// <param name="spanId">The id of the span.</param>
         /// <param name="baggage">The MockContext takes ownership of the baggage parameter.</param>
         /// <seealso cref="MockSpanContext.WithBaggageItem(string, string)"/>
-        internal MockSpanContext(long traceId, long spanId, IDictionary<string, string> baggage)
+        internal MockSpanContext(string traceId, string spanId, IDictionary<string, string> baggage)
         {
             TraceId = traceId;
             SpanId = spanId;

--- a/src/OpenTracing/Mock/Propagators.cs
+++ b/src/OpenTracing/Mock/Propagators.cs
@@ -64,8 +64,8 @@ namespace OpenTracing.Mock
 
         public MockSpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
         {
-            long? traceId = null;
-            long? spanId = null;
+            string traceId = null;
+            string spanId = null;
             Dictionary<string, string> baggage = new Dictionary<string, string>();
 
             if (carrier is ITextMap text)
@@ -74,11 +74,11 @@ namespace OpenTracing.Mock
                 {
                     if (TraceIdKey.Equals(entry.Key))
                     {
-                        traceId = Convert.ToInt64(entry.Value);
+                        traceId = entry.Value;
                     }
                     else if (SpanIdKey.Equals(entry.Key))
                     {
-                        spanId = Convert.ToInt64(entry.Value);
+                        spanId = entry.Value;
                     }
                     else if (entry.Key.StartsWith(BaggageKeyPrefix))
                     {
@@ -92,9 +92,9 @@ namespace OpenTracing.Mock
                 throw new InvalidOperationException($"Unknown carrier [{carrier.GetType()}]");
             }
 
-            if (traceId.HasValue && spanId.HasValue)
+            if (!string.IsNullOrEmpty(traceId) && !string.IsNullOrEmpty(spanId))
             {
-                return new MockSpanContext(traceId.Value, spanId.Value, baggage);
+                return new MockSpanContext(traceId, spanId, baggage);
             }
 
             return null;

--- a/src/OpenTracing/Noop/NoopSpanContext.cs
+++ b/src/OpenTracing/Noop/NoopSpanContext.cs
@@ -11,6 +11,10 @@ namespace OpenTracing.Noop
         {
         }
 
+        public string TraceId { get; }
+
+        public string SpanId { get; }
+
         public IEnumerable<KeyValuePair<string, string>> GetBaggageItems()
         {
             return Enumerable.Empty<KeyValuePair<string, string>>();

--- a/test/OpenTracing.Tests/Mock/MockTracerTests.cs
+++ b/test/OpenTracing.Tests/Mock/MockTracerTests.cs
@@ -43,9 +43,9 @@ namespace OpenTracing.Tests.Mock
             Assert.Single(finishedSpans);
             MockSpan finishedSpan = finishedSpans[0];
             Assert.Equal("tester", finishedSpan.OperationName);
-            Assert.Equal(0, finishedSpan.ParentId);
-            Assert.NotEqual(0, finishedSpan.Context.TraceId);
-            Assert.NotEqual(0, finishedSpan.Context.SpanId);
+            Assert.Null(finishedSpan.ParentId);
+            Assert.NotNull(finishedSpan.Context.TraceId);
+            Assert.NotNull(finishedSpan.Context.SpanId);
             Assert.Equal(FixedStartTimestamp, finishedSpan.StartTimestamp);
             Assert.Equal(FixedFinishTimestamp, finishedSpan.FinishTimestamp);
 


### PR DESCRIPTION
This implements the new ["Trace Identifiers RFC"](https://github.com/opentracing/specification/blob/master/rfc/trace_identifiers.md) by adding `TraceId` & `SpanId` members to `ISpanContext`.

The interesting thing to discuss here is the naming collision with existing tracer properties - e.g. `MockTracer` already had properties with the same names.

In this PR I changed the `MockTracer` properties to `string` but C# also has the possibility to "explicitly implement an interface" which would make it possible to keep the properties as `long`. This would look like this:

```csharp
public sealed class MockSpanContext : ISpanContext
{
    // The tracer has its own TraceId property with whatever type it wants
    public long TraceId { get; }
    
    // Whenever someone works with the `ISpanContext` interface, 
    // he can still access the `string` version of TraceId.
    string ISpanContext.TraceId => TraceId.ToString(CultureInfo.InvariantCulture);
}

// Usage examples:

// Type is string because we have ISpanContext.
ISpanContext context = span.Context;
string traceId = context.TraceId;

// Type is long because we use the concrete type.
MockSpanContext context = (MockSpanContext)span.Context;
long traceId = context.TraceId;
```

Obviously, this is a bit confusing as it's quite easy to get the "wrong" type depending on what one is doing. 

As `MockTracer` is used for unit tests where checking these properties is often necessary, I thought that changing the types to `string` makes this much less confusing.

For a real tracer, just explicitly implementing the interface and keeping the original types for its properties might be the best option though.