### PR TITLE
AsyncLocalScopeManager isolation

### DIFF
--- a/src/OpenTracing/Util/AsyncLocalScopeManager.cs
+++ b/src/OpenTracing/Util/AsyncLocalScopeManager.cs
@@ -16,7 +16,7 @@ namespace OpenTracing.Util
     public class AsyncLocalScopeManager : IScopeManager
     {
 #if NET45 // AsyncLocal is .NET 4.6+, so fall back to CallContext for .NET 4.5
-        private static readonly string s_logicalDataKey = "__AsyncLocalScope_Current__" + AppDomain.CurrentDomain.Id;
+        private readonly string s_logicalDataKey = "__AsyncLocalScope_Current__" + Guid.NewGuid().ToString("D");
 
         public IScope Active
         {
@@ -31,7 +31,7 @@ namespace OpenTracing.Util
             }
         }
 #else
-        private static AsyncLocal<IScope> s_current = new AsyncLocal<IScope>();
+        private AsyncLocal<IScope> s_current = new AsyncLocal<IScope>();
 
         public IScope Active
         {

--- a/src/OpenTracing/Util/AsyncLocalScopeManager.cs
+++ b/src/OpenTracing/Util/AsyncLocalScopeManager.cs
@@ -16,27 +16,27 @@ namespace OpenTracing.Util
     public class AsyncLocalScopeManager : IScopeManager
     {
 #if NET45 // AsyncLocal is .NET 4.6+, so fall back to CallContext for .NET 4.5
-        private readonly string s_logicalDataKey = "__AsyncLocalScope_Current__" + Guid.NewGuid().ToString("D");
+        private readonly string _logicalDataKey = "__AsyncLocalScope_Current__" + Guid.NewGuid().ToString("D");
 
         public IScope Active
         {
             get
             {
-                var handle = CallContext.LogicalGetData(s_logicalDataKey) as ObjectHandle;
+                var handle = CallContext.LogicalGetData(_logicalDataKey) as ObjectHandle;
                 return handle?.Unwrap() as IScope;
             }
             set
             {
-                CallContext.LogicalSetData(s_logicalDataKey, new ObjectHandle(value));
+                CallContext.LogicalSetData(_logicalDataKey, new ObjectHandle(value));
             }
         }
 #else
-        private AsyncLocal<IScope> s_current = new AsyncLocal<IScope>();
+        private readonly AsyncLocal<IScope> _current = new AsyncLocal<IScope>();
 
         public IScope Active
         {
-            get => s_current.Value;
-            set => s_current.Value = value;
+            get => _current.Value;
+            set => _current.Value = value;
         }
 #endif
 

--- a/test/OpenTracing.Tests/Util/AsyncLocalScopeManagerTests.cs
+++ b/test/OpenTracing.Tests/Util/AsyncLocalScopeManagerTests.cs
@@ -4,6 +4,8 @@ using Xunit;
 
 namespace OpenTracing.Tests.Util
 {
+    using OpenTracing.Mock;
+
     public class AsyncLocalScopeManagerTests
     {
         private AsyncLocalScopeManager _source;
@@ -12,6 +14,21 @@ namespace OpenTracing.Tests.Util
         public AsyncLocalScopeManagerTests()
         {
             _source = new AsyncLocalScopeManager();
+        }
+
+        [Fact]
+        public void InstancesSouldNotShareData()
+        {
+            AsyncLocalScopeManager manager1 = new AsyncLocalScopeManager();
+            AsyncLocalScopeManager manager2 = new AsyncLocalScopeManager();
+
+            AsyncLocalScope manager1Scope = new AsyncLocalScope(manager1, Substitute.For<ISpan>(), false);
+            manager1.Active = manager1Scope;
+            AsyncLocalScope manager2Scope = new AsyncLocalScope(manager2, Substitute.For<ISpan>(), false);
+            manager2.Active = manager2Scope;
+
+            Assert.Same(manager1Scope, manager1.Active);
+            Assert.Same(manager2Scope, manager2.Active);
         }
 
         [Fact]

--- a/test/OpenTracing.Tests/Util/AsyncLocalScopeManagerTests.cs
+++ b/test/OpenTracing.Tests/Util/AsyncLocalScopeManagerTests.cs
@@ -1,11 +1,10 @@
 ﻿using NSubstitute;
+using OpenTracing.Mock;
 using OpenTracing.Util;
 using Xunit;
 
 namespace OpenTracing.Tests.Util
 {
-    using OpenTracing.Mock;
-
     public class AsyncLocalScopeManagerTests
     {
         private AsyncLocalScopeManager _source;
@@ -17,7 +16,7 @@ namespace OpenTracing.Tests.Util
         }
 
         [Fact]
-        public void InstancesSouldNotShareData()
+        public void InstancesShouldNotShareData()
         {
             AsyncLocalScopeManager manager1 = new AsyncLocalScopeManager();
             AsyncLocalScopeManager manager2 = new AsyncLocalScopeManager();


### PR DESCRIPTION
Fixes #93. https://github.com/opentracing/opentracing-csharp/commit/aef788dda7b577ffce25714348076d5b0cdde0d0 demonstrates a test that fails before the change and passes after it.

**Problem:** Separate instances of `AsyncLocalScopeManager` will overwrite each other's data.
**Fix:** Use non-static `AsyncLocal` in the non-static `AsyncLocalScopeManager` class, and use `Guid` instead of `AppDomain.Id` for the pre4.6 implementation.