### PR TITLE
Calculate version number based on environment/github tag

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,14 +12,7 @@ environment:
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
 build_script:
-  - ps: |
-        if ($env:APPVEYOR_REPO_TAG -eq $true) {
-            $VersionSuffix = ""
-        }
-        else {
-            $VersionSuffix = "ci" + $env:APPVEYOR_BUILD_NUMBER.PadLeft(4, "0")
-        }
-  - ps: .\build.ps1 -VersionSuffix $VersionSuffix
+  - ps: .\build.ps1
 
 test: off
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,11 @@
 <Project>
+  <Import Project="version.props" />
   <PropertyGroup>
-    <VersionPrefix>0.12.0</VersionPrefix>
     <Authors>The OpenTracing Authors</Authors>
     <PackageIconUrl>https://avatars0.githubusercontent.com/u/15482765</PackageIconUrl>
     <PackageProjectUrl>https://github.com/opentracing/opentracing-csharp</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/opentracing/opentracing-csharp/master/LICENSE</PackageLicenseUrl>
-    <PackageReleaseNotes>https://github.com/opentracing/opentracing-csharp/releases/tag/$(VersionPrefix)</PackageReleaseNotes>
+    <PackageReleaseNotes Condition="'$(Version)' != ''">https://github.com/opentracing/opentracing-csharp/releases/tag/$(Version)</PackageReleaseNotes>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/opentracing/opentracing-csharp</RepositoryUrl>
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,5 @@
 ﻿[CmdletBinding(PositionalBinding = $false)]
 param(
-    [string] $VersionSuffix = "loc" + ((Get-Date).ToUniversalTime().ToString("yyyyMMddHHmm")),
     [string] $ArtifactsPath = (Join-Path $PWD "artifacts"),
     [string] $BuildConfiguration = "Release",
 
@@ -40,7 +39,6 @@ Task "Init" $true {
     if ($BuildConfiguration -eq $null) { throw "Property 'BuildConfiguration' may not be null." }
     if ((Get-Command "dotnet" -ErrorAction SilentlyContinue) -eq $null) { throw "'dotnet' command not found. Is .NET Core SDK installed?" }
 
-    Write-Host "VersionSuffix: $VersionSuffix"
     Write-Host "ArtifactsPath: $ArtifactsPath"
     Write-Host "BuildConfiguration: $BuildConfiguration"
     Write-Host ".NET Core SDK: $(dotnet --version)`n"
@@ -54,7 +52,6 @@ Task "Build" $RunBuild {
 
     dotnet msbuild "/t:Restore;Build;Pack" "/p:CI=true" `
         "/p:Configuration=$BuildConfiguration" `
-        "/p:VersionSuffix=$VersionSuffix" `
         "/p:PackageOutputPath=$(Join-Path $ArtifactsPath "nuget")"
 
     if ($LASTEXITCODE -ne 0) { throw "Build failed." }

--- a/version.props
+++ b/version.props
@@ -1,0 +1,27 @@
+<Project>
+  <PropertyGroup>
+    <!--
+      These settings ensure that we don't have to manually increment version numbers after every release!
+
+      If there's an AppVeyor tag, we always build with that tag name as the <Version>.
+      This overwrites any <VersionPrefix> and <VersionSuffix> so the tag MUST have a SemVer-compatible name!
+
+      Any non-official (non-tagged) build uses a fixed (high) <VersionPrefix> and an incrementing suffix.
+      This ensures that people who want to reference a package from a regular build can do so by specifying
+      the complete version (e.g. 99.99.99-b0014 or 99.99.99-*) which will always
+      be higher than any official release and therefore will always take priority.
+    -->
+
+    <!-- Prefix for non-tagged (local/regular CI) builds -->
+    <VersionPrefix>99.99.99</VersionPrefix>
+
+    <!-- Suffix for loal builds -->
+    <VersionSuffix>loc$([System.DateTime]::UtcNow.ToString('yyyyMMddHHmm'))</VersionSuffix>
+
+    <!-- Suffix for regular AppVeyor builds -->
+    <VersionSuffix Condition="'$(APPVEYOR_BUILD_NUMBER)' != ''">b$([System.Int32]::Parse($(APPVEYOR_BUILD_NUMBER)).ToString('D4'))</VersionSuffix>
+
+    <!-- Overwrite everything if there's an AppVeyor tag -->
+    <Version Condition="'$(APPVEYOR_REPO_TAG_NAME)' != ''">$(APPVEYOR_REPO_TAG_NAME)</Version>
+  </PropertyGroup>
+</Project>

--- a/version.props
+++ b/version.props
@@ -19,7 +19,7 @@
     <VersionSuffix>loc$([System.DateTime]::UtcNow.ToString('yyyyMMddHHmm'))</VersionSuffix>
 
     <!-- Suffix for regular AppVeyor builds -->
-    <VersionSuffix Condition="'$(APPVEYOR_BUILD_NUMBER)' != ''">b$([System.Int32]::Parse($(APPVEYOR_BUILD_NUMBER)).ToString('D4'))</VersionSuffix>
+    <VersionSuffix Condition="'$(APPVEYOR_BUILD_NUMBER)' != ''">ci$([System.Int32]::Parse($(APPVEYOR_BUILD_NUMBER)).ToString('D4'))</VersionSuffix>
 
     <!-- Overwrite everything if there's an AppVeyor tag -->
     <Version Condition="'$(APPVEYOR_REPO_TAG_NAME)' != ''">$(APPVEYOR_REPO_TAG_NAME)</Version>


### PR DESCRIPTION
I'd like to do a RC-release with the upcoming changes. However, this is not possible with the current build script as it will always do a VersionSuffix-less release if there's a git tag.

With these changes, I introduced a separate version.props file that now contains all of the version number logic (similar to ASP.NET Core projects). I'm copying the description with the new logic from that file here for further details:

>These settings ensure that we don't have to manually increment version numbers after every release!
>
>If there's an AppVeyor tag, we always build with that tag name as the Version.
This overwrites any VersionPrefix and VersionSuffix so the tag MUST have a SemVer-compatible name!
>
>Any non-official (non-tagged) build uses a fixed (high) VersionPrefix and an incrementing suffix.
This ensures that people who want to reference a package from a regular build can do so by specifying
the complete version (e.g. 99.99.99-b0014 or 99.99.99-*) which will always
be higher than any official release and therefore will always take priority.

The thing to discuss might be the "99.99.99" version for local / regular CI builds. I have this trick from the XUnit project. The advantage with this is that we will never have to bump the version manually again (which is really easy to forget).