### PR TITLE
Add a binary propagator format option

### DIFF
--- a/examples/OpenTracing.Examples/LateSpanFinish/LateSpanFinishTest.cs
+++ b/examples/OpenTracing.Examples/LateSpanFinish/LateSpanFinishTest.cs
@@ -46,7 +46,7 @@ namespace OpenTracing.Examples.LateSpanFinish
             {
                 using (IScope childScope1 = _tracer.BuildSpan("task1").StartActive(finishSpanOnDispose:true))
                 {
-                    await Task.Delay(55);
+                    await Task.Delay(100);
                 }
             });
 
@@ -54,7 +54,7 @@ namespace OpenTracing.Examples.LateSpanFinish
             {
                 using (IScope childScope2 = _tracer.BuildSpan("task2").StartActive(finishSpanOnDispose:true))
                 {
-                    await Task.Delay(85);
+                    await Task.Delay(500);
                 }
             });
 

--- a/src/OpenTracing/Propagation/BuiltinFormats.cs
+++ b/src/OpenTracing/Propagation/BuiltinFormats.cs
@@ -1,4 +1,6 @@
-﻿namespace OpenTracing.Propagation
+﻿using System.IO;
+
+namespace OpenTracing.Propagation
 {
     public static class BuiltinFormats
     {
@@ -24,6 +26,16 @@
         /// <seealso cref="IFormat{TCarrier}"/>
         /// <seealso cref="TextMap"/>
         public static readonly IFormat<ITextMap> HttpHeaders = new Builtin<ITextMap>("HTTP_HEADERS");
+
+        /// <summary>
+        /// The 'Binary' format allows for unconstrained byte encoding of <see cref="ISpanContext"/> state
+        /// for <see cref="ITracer.Inject{TCarrier}"/> and <see cref="ITracer.Extract{TCarrier}"/> using a <see cref="MemoryStream"/>.
+        /// </summary>
+        /// <seealso cref="ITracer.Inject{TCarrier}"/>
+        /// <seealso cref="ITracer.Extract{TCarrier}"/>
+        /// <seealso cref="IFormat{TCarrier}"/>
+        /// <seealso cref="byte"/>
+        public static readonly IFormat<Stream> Binary = new Builtin<Stream>("BINARY");
 
         private struct Builtin<TCarrier> : IFormat<TCarrier>
         {

--- a/src/OpenTracing/Propagation/BuiltinFormats.cs
+++ b/src/OpenTracing/Propagation/BuiltinFormats.cs
@@ -30,6 +30,7 @@ namespace OpenTracing.Propagation
         /// <summary>
         /// The 'Binary' format allows for unconstrained byte encoding of <see cref="ISpanContext"/> state
         /// for <see cref="ITracer.Inject{TCarrier}"/> and <see cref="ITracer.Extract{TCarrier}"/> using a <see cref="MemoryStream"/>.
+        /// Note that this should be considered experimental, and subject to change.
         /// </summary>
         /// <seealso cref="ITracer.Inject{TCarrier}"/>
         /// <seealso cref="ITracer.Extract{TCarrier}"/>


### PR DESCRIPTION
This adds a builtin Binary Propagator format for consumers of the API.