### PR TITLE
Fix minor documentation comment issues

### DIFF
--- a/src/OpenTracing/ITracer.cs
+++ b/src/OpenTracing/ITracer.cs
@@ -62,7 +62,7 @@ namespace OpenTracing
         /// <param name="spanContext">The <see cref="ISpanContext"/> instance to inject into the <paramref name="carrier"/>.</param>
         /// <param name="format">The <see cref="IFormat{TCarrier}"/> of the <paramref name="carrier"/>.</param>
         /// <param name="carrier">
-        /// The carrier for the <see cref="ISpanContext"/> state. All <see cref="Inject"/> implementations must support
+        /// The carrier for the <see cref="ISpanContext"/> state. All <see cref="Inject{TCarrier}"/> implementations must support
         /// <see cref="ITextMap"/> and <see cref="Stream"/>.
         /// </param>
         /// <seealso cref="IFormat{TCarrier}"/>
@@ -88,7 +88,7 @@ namespace OpenTracing
         /// <typeparam name="TCarrier">The <paramref name="carrier"/> type, which also parametrizes the <paramref name="format"/>.</typeparam>
         /// <param name="format">The <see cref="IFormat{TCarrier}"/> of the <paramref name="carrier"/>.</param>
         /// <param name="carrier">
-        /// The carrier for the <see cref="ISpanContext"/> state. All <see cref="Extract"/> implementations must support
+        /// The carrier for the <see cref="ISpanContext"/> state. All <see cref="Extract{TCarrier}"/> implementations must support
         /// <see cref="ITextMap"/> and <see cref="Stream"/>.
         /// </param>
         /// <returns>The <see cref="ISpanContext"/> instance holding context to create a span.</returns>

--- a/src/OpenTracing/Mock/MockSpan.cs
+++ b/src/OpenTracing/Mock/MockSpan.cs
@@ -39,7 +39,7 @@ namespace OpenTracing.Mock
         private readonly List<Exception> _errors = new List<Exception>();
 
         /// <summary>
-        /// The spanId of the span's first <see cref="References.ChildOf"/> reference, or the first reference of any type,
+        /// The spanId of the span's first <see cref="OpenTracing.References.ChildOf"/> reference, or the first reference of any type,
         /// or null if no reference exists.
         /// </summary>
         /// <seealso cref="MockSpanContext.SpanId"/>

--- a/src/OpenTracing/Mock/MockTracer.cs
+++ b/src/OpenTracing/Mock/MockTracer.cs
@@ -44,7 +44,7 @@ namespace OpenTracing.Mock
 
         /// <summary>
         /// Create a new <see cref="MockTracer"/> that passes through any calls
-        /// to <see cref="ITracer.Inject"/> and/or <see cref="ITracer.Extract"/>.
+        /// to <see cref="ITracer.Inject{TCarrier}"/> and/or <see cref="ITracer.Extract{TCarrier}"/>.
         /// </summary>
         public MockTracer(IPropagator propagator)
             : this(new AsyncLocalScopeManager(), propagator)

--- a/src/OpenTracing/Mock/Propagators.cs
+++ b/src/OpenTracing/Mock/Propagators.cs
@@ -12,7 +12,7 @@ namespace OpenTracing.Mock
     }
 
     /// <summary>
-    /// Allows the developer to inject into the <see cref="MockTracer.Inject"/> and <see cref="MockTracer.Extract"/> calls.
+    /// Allows the developer to inject into the <see cref="MockTracer.Inject{TCarrier}"/> and <see cref="MockTracer.Extract{TCarrier}"/> calls.
     /// </summary>
     public interface IPropagator
     {

--- a/src/OpenTracing/Propagation/TextMapExtractAdapter.cs
+++ b/src/OpenTracing/Propagation/TextMapExtractAdapter.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 namespace OpenTracing.Propagation
 {
     /// <summary>
-    /// A <see cref="ITextMap"/> carrier for use with <see cref="ITracer.Extract"/> ONLY (it has no mutating methods). Note that the
+    /// A <see cref="ITextMap"/> carrier for use with <see cref="ITracer.Extract{TCarrier}"/> ONLY (it has no mutating methods). Note that the
     /// <see cref="ITextMap"/> interface can be made to wrap around arbitrary data types
     /// (not just <code>Dictionary&lt;string, string&gt;</code> as illustrated here).
     /// </summary>


### PR DESCRIPTION
I opened the repo with JetBrains Rider and it marked a couple of things in documentation comments with error.

Mainly 2 things:

- Missing generic parameter
- Missing namespace in `MockSpan.cs` without `using`

I think based on the specs those are correct and VS has no problem with it, still with this PR 1) Rider shows no errors anymore and 2) I see that the docs almost always use generic parameters, except in the cases this PR fixes, so this'd add consistency.