### PR TITLE
Improve thread-safety in GlobalTracer.IsRegistered

### DIFF
--- a/src/OpenTracing/Util/GlobalTracer.cs
+++ b/src/OpenTracing/Util/GlobalTracer.cs
@@ -61,7 +61,10 @@ namespace OpenTracing.Util
         /// <returns>Whether a tracer has been registered.</returns>
         public static bool IsRegistered()
         {
-            return s_isRegistered;
+            lock (s_lock)
+            {
+                return s_isRegistered;
+            }
         }
 
         /// <summary>

--- a/src/OpenTracing/Util/GlobalTracer.cs
+++ b/src/OpenTracing/Util/GlobalTracer.cs
@@ -61,10 +61,7 @@ namespace OpenTracing.Util
         /// <returns>Whether a tracer has been registered.</returns>
         public static bool IsRegistered()
         {
-            lock (s_lock)
-            {
-                return s_isRegistered;
-            }
+            return s_isRegistered;
         }
 
         /// <summary>

--- a/src/OpenTracing/Util/GlobalTracer.cs
+++ b/src/OpenTracing/Util/GlobalTracer.cs
@@ -68,6 +68,44 @@ namespace OpenTracing.Util
         }
 
         /// <summary>
+        /// Attempts to register a <see cref="ITracer"/> to back the behaviour of the global tracer (<see cref="Instance"/>).
+        /// <para>
+        /// Registration is a one-time operation, subsequent attempts do not change the registered global tracer.
+        /// </para>
+        /// </summary>
+        /// <param name="tracer">The tracer to use as the global tracer.</param>
+        /// <returns>True if the tracer was successfully registered, otherwise false.</returns>
+        public static bool RegisterIfAbsent(ITracer tracer)
+        {
+            if (tracer == null)
+                throw new ArgumentNullException(nameof(tracer), "Cannot register GlobalTracer <null>.");
+
+            if (tracer is GlobalTracer)
+                throw new ArgumentException("Attempted to register the GlobalTracer as delegate of itself.", nameof(tracer));
+
+            lock (s_lock)
+            {
+                // if re-registering the same tracer, just return true
+                if (tracer == s_instance._tracer)
+                {
+                    s_isRegistered = true;
+                    return true;
+                }
+
+                // if a tracer is already registered, return false
+                if (s_isRegistered)
+                {
+                    return false;
+                }
+
+                s_instance._tracer = tracer;
+                s_isRegistered = true;
+
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Register a <see cref="ITracer"/> to back the behaviour of the global tracer (<see cref="Instance"/>).
         /// <para/>
         /// Registration is a one-time operation, attempting to call it more often will result in a runtime exception.
@@ -78,25 +116,11 @@ namespace OpenTracing.Util
         /// <param name="tracer">Tracer to use as global tracer.</param>
         public static void Register(ITracer tracer)
         {
-            if (tracer == null)
-                throw new ArgumentNullException(nameof(tracer), "Cannot register GlobalTracer <null>.");
-
-            if (tracer is GlobalTracer)
-                throw new ArgumentException("Attempted to register the GlobalTracer as delegate of itself.", nameof(tracer));
-
-            lock (s_lock)
+            if (!RegisterIfAbsent(tracer) &&
+                tracer != s_instance._tracer &&
+                !(tracer is GlobalTracer))
             {
-                if (tracer == s_instance._tracer)
-                {
-                    s_isRegistered = true;
-                    return;
-                }
-
-                if (IsRegistered())
-                    throw new InvalidOperationException("There is already a current global Tracer registered.");
-
-                s_instance._tracer = tracer;
-                s_isRegistered = true;
+                throw new InvalidOperationException("There is already a current global Tracer registered.");
             }
         }
 

--- a/test/OpenTracing.Tests/Util/GlobalTracerTests.cs
+++ b/test/OpenTracing.Tests/Util/GlobalTracerTests.cs
@@ -126,5 +126,19 @@ namespace OpenTracing.Tests.Util
 
             Assert.True(GlobalTracer.IsRegistered());
         }
+
+        [Fact]
+        public void RegisterIfAbsent_called_multiple_times_does_not_throw_exception()
+        {
+            Assert.False(GlobalTracer.IsRegistered());
+
+            for (var i = 0; i < 10; i++)
+            {
+                var tracer = Substitute.For<ITracer>();
+                GlobalTracer.RegisterIfAbsent(tracer);                
+
+                Assert.True(GlobalTracer.IsRegistered());
+            }
+        }
     }
 }


### PR DESCRIPTION
Addresses #118 by wrapping `GlobalTracer.IsRegistered()` in a lock statement.

I've also implemented `GlobalTracer.RegisterIfAbsent(tracer)` that returns a bool to indicate if the registration was successful or not. This was copied from [opentracing-java](https://github.com/opentracing/opentracing-java/blob/master/opentracing-util/src/main/java/io/opentracing/util/GlobalTracer.java#L116).