### PR TITLE
Improve Binary Propagator

### DIFF
--- a/src/OpenTracing/Propagation/BinaryExtractAdapter.cs
+++ b/src/OpenTracing/Propagation/BinaryExtractAdapter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace OpenTracing.Propagation
+{
+    /// <summary>
+    /// A <see cref="IBinary"/> carrier for use with <see cref="ITracer.Extract{TCarrier}"/> only. It cannot be mutated, only read.
+    /// </summary>
+    /// <seealso cref="ITracer.Extract{TCarrier}"/>
+    public class BinaryExtractAdapter : IBinary
+    {
+        private readonly MemoryStream _stream;
+
+        public BinaryExtractAdapter(MemoryStream stream)
+        {
+            _stream = stream;
+        }
+        
+        /// <inheritdoc />
+        public void Set(MemoryStream stream)
+        {
+            throw new NotSupportedException($"{nameof(BinaryExtractAdapter)} should only be used with {nameof(ITracer)}.{nameof(ITracer.Extract)}");
+        }
+
+        /// <inheritdoc />
+        public MemoryStream Get()
+        {
+            return _stream;
+        }
+    }
+}

--- a/src/OpenTracing/Propagation/BinaryInjectAdapter.cs
+++ b/src/OpenTracing/Propagation/BinaryInjectAdapter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+
+namespace OpenTracing.Propagation
+{
+    /// <summary>
+    /// A <see cref="IBinary"/> carrier for use with <see cref="ITracer.Inject{TCarrier}"/> only. It cannot be read, only set.
+    /// </summary>
+    /// <seealso cref="ITracer.Extract{TCarrier}"/>
+    public class BinaryInjectAdapter : IBinary
+    {
+        private MemoryStream _stream;
+
+        public BinaryInjectAdapter(MemoryStream stream)
+        {
+            _stream = stream;
+        }
+        
+        /// <inheritdoc />
+        public void Set(MemoryStream stream)
+        {
+            _stream = stream;
+        }
+        
+        /// <inheritdoc />
+        public MemoryStream Get()
+        {
+            throw new NotSupportedException($"{nameof(BinaryInjectAdapter)} should only be used with {nameof(ITracer)}.{nameof(ITracer.Inject)}");
+        }
+        
+    }
+}

--- a/src/OpenTracing/Propagation/BuiltinFormats.cs
+++ b/src/OpenTracing/Propagation/BuiltinFormats.cs
@@ -30,13 +30,12 @@ namespace OpenTracing.Propagation
         /// <summary>
         /// The 'Binary' format allows for unconstrained byte encoding of <see cref="ISpanContext"/> state
         /// for <see cref="ITracer.Inject{TCarrier}"/> and <see cref="ITracer.Extract{TCarrier}"/> using a <see cref="MemoryStream"/>.
-        /// Note that this should be considered experimental, and subject to change.
         /// </summary>
         /// <seealso cref="ITracer.Inject{TCarrier}"/>
         /// <seealso cref="ITracer.Extract{TCarrier}"/>
         /// <seealso cref="IFormat{TCarrier}"/>
         /// <seealso cref="byte"/>
-        public static readonly IFormat<Stream> Binary = new Builtin<Stream>("BINARY");
+        public static readonly IFormat<IBinary> Binary = new Builtin<IBinary>("BINARY");
 
         private struct Builtin<TCarrier> : IFormat<TCarrier>
         {

--- a/src/OpenTracing/Propagation/IBinary.cs
+++ b/src/OpenTracing/Propagation/IBinary.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace OpenTracing.Propagation
+{
+    /// <summary>
+    /// <see cref="IBinary"/> is a built-in carrier for <see cref="ITracer.Inject{TCarrier}"/> and
+    /// <see cref="ITracer.Extract{TCarrier}"/>. IBinary implementations allow for the reading and writing of arbitrary streams.
+    /// </summary>
+    /// <seealso cref="ITracer.Inject{TCarrier}"/>
+    /// <seealso cref="ITracer.Extract{TCarrier}"/>
+    public interface IBinary
+    {
+        /// <summary>
+        /// Sets the backing MemoryStream of an <see cref="IBinary"/> store.
+        /// </summary>
+        /// <param name="stream">A memory-backed stream.</param>
+        void Set(MemoryStream stream);
+
+        /// <summary>
+        /// Gets the backing MemoryStream of an <see cref="IBinary"/> store.
+        /// </summary>
+        /// <returns></returns>
+        MemoryStream Get();
+    }
+}


### PR DESCRIPTION
I've refactored the binary propagator to work like the TextMap propagator.

- Added `IBinary` interface which is implemented by `BinaryInjectAdapter` and `BinaryExtractAdapter`.
- `IBinary` offers a get and set method.
- `IBinary` is explicitly backed by a `MemoryStream`.

This is a bit different than the Java implementation, but we don't need to pass the length along like they do over there. This PR is mostly in support of adding support for decoding Envoy `x-ot-span-context` headers to OpenTracing tracers.