### PR TITLE
Updates GitHub token for creating releases

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,6 +33,6 @@ deploy:
     description: "See milestone for changes: https://github.com/opentracing/opentracing-csharp/releases"
     draft: true
     auth_token:
-      secure: VD2KNkqKnAIEm3QWxqCLC3KaVrQjfxsaV9NiuLCvrTEAk4p5ZmI462RA4qoB21KS
+      secure: 05KasH/6S6S8XqW70igCQOUMs8NmvjDbdojF7mZlvWHFEZ8B8c6/tmBEoRT636ui
     on:
       appveyor_repo_tag: true


### PR DESCRIPTION
The existing GitHub token for creating releases no longer worked ( https://ci.appveyor.com/project/opentracing/opentracing-csharp/builds/26543348 ), I have therefore created a new personal access token in GitHub and I've updated the script to contain the AppVeyor-encrypted version of it.

I've tested this with a new tag (0.12.1-cwtest) and it worked ( https://ci.appveyor.com/project/opentracing/opentracing-csharp ). 

I've already deleted the corresponding tag and draft-release!